### PR TITLE
fix: sed delimiter

### DIFF
--- a/hermes_agent/run.sh
+++ b/hermes_agent/run.sh
@@ -321,7 +321,7 @@ if [ -f "$SRC_DIR/web/package.json" ]; then
        ! grep -q 'HA-ADDON-ROUTER-BASENAME-PATCHED' "$SRC_DIR/web/src/main.tsx" 2>/dev/null; then
         sed -i \
             -e 's|import { BrowserRouter } from "react-router-dom";|import { BrowserRouter } from "react-router-dom";\nimport { BASE } from "@/lib/api"; /* HA-ADDON-ROUTER-BASENAME-PATCHED */|' \
-            -e 's|<BrowserRouter>|<BrowserRouter basename={BASE || "/"}>|' \
+            -e 's#<BrowserRouter>#<BrowserRouter basename={BASE || "/"}>#' \
             "$SRC_DIR/web/src/main.tsx"
         if ! grep -q 'basename={BASE || "/"}' "$SRC_DIR/web/src/main.tsx" 2>/dev/null; then
             echo "[run] WARNING: main.tsx BrowserRouter pattern changed upstream — dashboard links may 404 behind /dashboard/"


### PR DESCRIPTION
`sed` used `|` as the delimiter while the replacement contained JavaScript `BASE || "/"`, so `sed` parsed the `||` as delimiter syntax

Fix https://github.com/WolframRavenwolf/hermes-ha-addon/issues/3
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wolframravenwolf/hermes-ha-addon/pull/4" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->