### PR TITLE
Add webhook proxy configuration to nginx ports template

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,23 @@ Both ports are configurable in the Home Assistant add-on network settings. Use t
 | **8080** | HTTP access (all URLs above, replace 8443 with 8080) |
 | **8443** | HTTPS access (TLS with self-signed cert)             |
 
+### Webhooks
+
+The Hermes gateway listens on port 8644 internally and receives webhook events from external services such as GitLab, GitHub, and other platforms. Webhook requests are proxied through nginx on port 8080/8443 to the gateway.
+
+| Path | Description |
+| ---- | ----------- |
+| `/webhooks/{subscription-name}` | Receive events for a configured webhook subscription |
+
+Webhooks use their own HMAC signature validation — no nginx Basic Auth is required (and none is applied). Configure subscriptions via:
+
+```bash
+hermes webhook create   # Create a new subscription
+hermes webhook list     # List active subscriptions
+```
+
+To expose webhooks externally, route your reverse proxy or Cloudflare tunnel to `http://<ha-ip>:8080` — the `/webhooks/` path is open, all other paths remain protected by Basic Auth.
+
 ### SSH
 
 Via Home Assistant host + docker exec, no SSH server in container required. Port 22222 is the default for the Advanced SSH & Web Terminal add-on (adjust if yours differs).
@@ -145,6 +162,7 @@ Authentication layers differ by access path:
 - **Direct HTTP/HTTPS Ports** (8080/8443): two-layer auth protects the web UIs.
   1. **Basic Auth** (username `hermes`, password = `access_password`) gates the landing page, Terminal, and Dashboard HTML.
   2. **Session Token** (ephemeral, rotates on every add-on restart) gates dashboard API calls. The token is injected into the dashboard HTML on load — only clients who successfully loaded the page via Basic Auth ever see it. Requests to `/dashboard/api/*` without a matching Bearer token return 401. Only `/dashboard/api/status` is public (it mirrors Hermes' own whitelist and powers the landing page health indicator). If the dashboard process is restarted without restarting the add-on, the nginx-side token cache goes stale — restart the add-on to re-sync.
+- **Webhook endpoints** (`/webhooks/*`): Basic Auth is **disabled** — webhooks are authenticated by HMAC signature validation inside the gateway (e.g. `X-Hub-Signature-256` for GitHub, `X-Gitlab-Token` for GitLab). Never modify the gateway secret; rotate it via `hermes webhook create` if compromised.
 - **OpenAI-compatible API** (`/v1/*`): Bearer token authentication. The `access_password` doubles as the API key, passed as `Authorization: Bearer <password>`.
 
 If you expose direct ports to the internet, place a network-perimeter gate (firewall, VPN, reverse proxy with stronger auth) in front — Basic Auth alone is not brute-force resistant.

--- a/hermes_agent/nginx-ports.conf.tpl
+++ b/hermes_agent/nginx-ports.conf.tpl
@@ -124,6 +124,20 @@
             add_header Content-Disposition 'attachment; filename="hermes-agent-ca.crt"';
         }
 
+        # WEBHOOK_START
+        location /webhooks/ {
+            %%AUTH_BASIC_OFF%%
+            proxy_pass http://127.0.0.1:8644/webhooks/;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_buffering off;
+            proxy_read_timeout 30s;
+            proxy_send_timeout 30s;
+        }
+        # WEBHOOK_END
+
         location = /health {
             %%AUTH_BASIC_OFF%%
             access_log off;
@@ -259,6 +273,20 @@
             default_type application/x-x509-ca-cert;
             add_header Content-Disposition 'attachment; filename="hermes-agent-ca.crt"';
         }
+
+        # WEBHOOK_START
+        location /webhooks/ {
+            %%AUTH_BASIC_OFF%%
+            proxy_pass http://127.0.0.1:8644/webhooks/;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_buffering off;
+            proxy_read_timeout 30s;
+            proxy_send_timeout 30s;
+        }
+        # WEBHOOK_END
 
         location = /health {
             %%AUTH_BASIC_OFF%%

--- a/hermes_agent/nginx-ports.conf.tpl
+++ b/hermes_agent/nginx-ports.conf.tpl
@@ -124,19 +124,7 @@
             add_header Content-Disposition 'attachment; filename="hermes-agent-ca.crt"';
         }
 
-        # WEBHOOK_START
-        location /webhooks/ {
-            %%AUTH_BASIC_OFF%%
-            proxy_pass http://127.0.0.1:8644/webhooks/;
-            proxy_http_version 1.1;
-            proxy_set_header Host $host;
-            proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-Proto $scheme;
-            proxy_buffering off;
-            proxy_read_timeout 30s;
-            proxy_send_timeout 30s;
-        }
-        # WEBHOOK_END
+        include /etc/nginx/webhooks.conf;
 
         location = /health {
             %%AUTH_BASIC_OFF%%
@@ -274,19 +262,7 @@
             add_header Content-Disposition 'attachment; filename="hermes-agent-ca.crt"';
         }
 
-        # WEBHOOK_START
-        location /webhooks/ {
-            %%AUTH_BASIC_OFF%%
-            proxy_pass http://127.0.0.1:8644/webhooks/;
-            proxy_http_version 1.1;
-            proxy_set_header Host $host;
-            proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-Proto $scheme;
-            proxy_buffering off;
-            proxy_read_timeout 30s;
-            proxy_send_timeout 30s;
-        }
-        # WEBHOOK_END
+        include /etc/nginx/webhooks.conf;
 
         location = /health {
             %%AUTH_BASIC_OFF%%

--- a/hermes_agent/run.sh
+++ b/hermes_agent/run.sh
@@ -530,6 +530,14 @@ else
     echo "[run] Direct ports: disabled (Ingress only)"
 fi
 
+# Render webhook config (always included — gateway always starts)
+cp /etc/nginx/webhooks.conf.tpl /etc/nginx/webhooks.conf
+sed -i \
+    -e "s|%%AUTH_BASIC_ON%%|${AUTH_BASIC_ON}|g" \
+    -e "s|%%AUTH_BASIC_OFF%%|${AUTH_BASIC_OFF}|g" \
+    /etc/nginx/webhooks.conf
+echo "[run] Webhook proxy: enabled on direct ports"
+
 cp /etc/nginx/nginx.conf.tpl /etc/nginx/nginx.conf
 sed -i \
     -e "s|%%INGRESS_PORT%%|${INGRESS_PORT}|g" \

--- a/hermes_agent/webhooks.conf.tpl
+++ b/hermes_agent/webhooks.conf.tpl
@@ -1,0 +1,14 @@
+# WEBHOOK_START
+    location /webhooks/ {
+        %%AUTH_BASIC_OFF%%
+        proxy_pass http://127.0.0.1:8644/webhooks/;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_buffering off;
+        proxy_read_timeout 30s;
+        proxy_send_timeout 30s;
+    }
+# WEBHOOK_END


### PR DESCRIPTION
## Summary

Adds `/webhooks/` location blocks to the nginx ports config template, proxying requests to the Hermes gateway on port 8644. Addresses all Copilot review feedback.

## Changes

- **Extracted webhook config** into `webhooks.conf.tpl` — included via `include /etc/nginx/webhooks.conf;` in both server blocks (no duplication)
- **Added `X-Forwarded-For`** header forwarding: `proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;`
- **Added rendering step** in `run.sh` to generate `webhooks.conf` from `webhooks.conf.tpl` at startup
- Auth is disabled — webhooks authenticate via their own HMAC signatures (X-Hub-Signature, X-Gitlab-Token, etc.)
- Standard proxy settings with no buffering, 30s timeouts

## Files changed

| File | Change |
|---|---|
| `hermes_agent/webhooks.conf.tpl` | **New** — shared webhook location block template |
| `hermes_agent/nginx-ports.conf.tpl` | Replaced inline webhook blocks with `include /etc/nginx/webhooks.conf;` |
| `hermes_agent/run.sh` | Added rendering step for `webhooks.conf.tpl` → `webhooks.conf` |

## Testing

```
$ curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:8080/webhooks/github-actions-honcho \
  -X POST -H "Content-Type: application/json" -d '{}'
HTTP 401  (expected — signature required, but routing works)
```