### PR TITLE
Fixes gateway startup loop with Hermes Agent v0.14.0.

### DIFF
--- a/hermes_agent/config.yaml
+++ b/hermes_agent/config.yaml
@@ -1,5 +1,5 @@
 name: Hermes Agent
-version: "1.0.7"
+version: "1.0.8"
 slug: hermes_agent
 description: "The self-improving AI agent built by Nous Research. Home Assistant add-on by Wolfram Ravenwolf."
 url: "https://github.com/WolframRavenwolf/hermes-ha-addon"

--- a/hermes_agent/run.sh
+++ b/hermes_agent/run.sh
@@ -584,10 +584,10 @@ start_gateway() {
     echo "[run] Starting Hermes gateway..."
     mkdir -p "$HERMES_HOME/logs"
     cd "$HERMES_HOME"
-    hermes -p default gateway run 2>&1 | tee -a "$HERMES_HOME/logs/gateway.log" &
+    HERMES_GATEWAY_NO_SUPERVISE=1 hermes gateway run 2>&1 | tee -a "$HERMES_HOME/logs/gateway.log" &
     TEE_PID=$!
     sleep 0.5  # let gateway fork
-    GATEWAY_PID=$(pgrep -f "hermes -p default gateway run" | sort -n | tail -1 || echo "$TEE_PID")
+    GATEWAY_PID=$(pgrep -f "hermes gateway run" | sort -n | tail -1 || echo "$TEE_PID")
     echo "[run] Gateway started (PID: $GATEWAY_PID, tee: $TEE_PID)"
 }
 

--- a/hermes_agent/run.sh
+++ b/hermes_agent/run.sh
@@ -1,7 +1,7 @@
 #!/command/with-contenv bash
-# ─────────────────────────────────────────────────────────────────────
+# ──────────────────────────────────────────────────────────────────[...]
 # Hermes Agent HA Add-on Entrypoint
-# ─────────────────────────────────────────────────────────────────────
+# ──────────────────────────────────────────────────────────────────[...]
 set -euo pipefail
 
 # ── Section 1: Read options ──────────────────────────────────────────
@@ -584,10 +584,10 @@ start_gateway() {
     echo "[run] Starting Hermes gateway..."
     mkdir -p "$HERMES_HOME/logs"
     cd "$HERMES_HOME"
-    hermes gateway run 2>&1 | tee -a "$HERMES_HOME/logs/gateway.log" &
+    hermes -p default gateway run 2>&1 | tee -a "$HERMES_HOME/logs/gateway.log" &
     TEE_PID=$!
     sleep 0.5  # let gateway fork
-    GATEWAY_PID=$(pgrep -f "hermes gateway run" | sort -n | tail -1 || echo "$TEE_PID")
+    GATEWAY_PID=$(pgrep -f "hermes -p default gateway run" | sort -n | tail -1 || echo "$TEE_PID")
     echo "[run] Gateway started (PID: $GATEWAY_PID, tee: $TEE_PID)"
 }
 

--- a/hermes_agent/run.sh
+++ b/hermes_agent/run.sh
@@ -587,7 +587,7 @@ start_gateway() {
     echo "[run] Starting Hermes gateway..."
     mkdir -p "$HERMES_HOME/logs"
     cd "$HERMES_HOME"
-    HERMES_GATEWAY_NO_SUPERVISE=1 hermes gateway run 2>&1 | tee -a "$HERMES_HOME/logs/gateway.log" &
+    hermes gateway run 2>&1 | tee -a "$HERMES_HOME/logs/gateway.log" &
     TEE_PID=$!
     sleep 0.5  # let gateway fork
     GATEWAY_PID=$(pgrep -f "hermes gateway run" | sort -n | tail -1 || echo "$TEE_PID")


### PR DESCRIPTION
## Summary
Fixes gateway startup loop with Hermes Agent v0.14.0.

## Problem
In Hermes Agent v0.14.0, running `hermes gateway run` inside a container environment attempts to redirect to its internal s6-supervision model (`gateway-default` slot). Since this add-on manages the gateway process directly via its own `run.sh` script and doesn't use the official Hermes container boot flow, the s6 service is not registered, causing the gateway to fail with `no such gateway 'default'` and enter a restart loop.

## Fix
Added `HERMES_GATEWAY_NO_SUPERVISE=1` to opt out of the internal s6 redirection, allowing the gateway to start normally in the foreground under the add-on's existing supervisor script.

## Tested
Tested on my local Home Assistant instance.
- Add-on starts successfully.
- Gateway no longer exits with `no such gateway 'default'`.
- Gateway process stays running.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wolframravenwolf/hermes-ha-addon/pull/10" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->