### PR TITLE
feat: multi-profile with single hermes installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,27 +46,30 @@ Add-on-level options are configured in the Home Assistant UI (Settings > Apps > 
 | `env_vars`            | `OPENROUTER_API_KEY` (example)                     | Hermes .env variables — written to each profile's `.env` on each start          |
 | `hermes_home`         | `.hermes`                                          | Single-profile mode: agent profile directory (relative to ~). Ignored if `profiles` is non-empty |
 | `profiles`            | `[]`                                               | Multi-profile mode: list of profile directories run concurrently. First entry is the primary |
+| `profiles_base`       | `.hermes/profiles`                                 | Default parent dir for bare profile names. Entries containing `/` or starting with `.` are taken as-is. Set to empty to disable the prefix |
 | `profile_env_vars`    | `[]`                                               | Per-profile `.env` overrides: each entry is `{profile, name, value}` where `profile` matches a directory in `profiles` |
 
 API keys can be configured in two places: `env_vars` above (convenient, via Home Assistant UI) or each profile's `.env` directly (full list, via terminal or `hermes setup`). Non-empty top-level `env_vars` are written to every profile's `.env` on each start, overriding existing entries. `profile_env_vars` entries layer on top of the top-level set for the profile whose directory matches `profile`.
 
 ### Running multiple profiles concurrently
 
-Set `profiles` to run several Hermes instances in the same add-on. Per-profile env overrides live in `profile_env_vars` and reference each profile by its directory string (the schema stays flat because Home Assistant Supervisor only allows nested objects two levels deep):
+Set `profiles` to run several Hermes instances in the same add-on. Bare names are placed under `profiles_base` (default `.hermes/profiles`) to match upstream's [profile layout](https://hermes-agent.nousresearch.com/docs/user-guide/profiles); entries containing `/` or starting with `.` are taken as-is. Per-profile env overrides live in a flat `profile_env_vars` list (Home Assistant Supervisor only allows nested objects two levels deep):
 
 ```yaml
 profiles:
-  - .hermes
-  - amy
-  - bob
+  - .hermes              # primary, lives at /config/.hermes
+  - finance-ana          # /config/.hermes/profiles/finance-ana
+  - team/coder           # /config/team/coder (already has a slash)
 profile_env_vars:
-  - profile: amy
+  - profile: finance-ana
     name: OPENROUTER_API_KEY
-    value: amy-only-key
-  - profile: amy
-    name: SOME_AMY_VAR
-    value: amy-special
+    value: finance-only-key
+  - profile: finance-ana
+    name: SOME_VAR
+    value: special
 ```
+
+A single shared install at `~/.hermes/hermes-agent` (clone + venv) backs every profile — only the per-profile `.env`, `config.yaml`, `SOUL.md`, sessions, memories, and logs live under each profile's directory.
 
 The first entry is the **primary** — it keeps the existing root URLs (`/hermes/`, `/dashboard/`, `/terminal/`, `/v1/`). Each additional profile is exposed under `/profile/<name>/...`. Per-profile ports allocate from a base + index (`8642`, `49269`, `49369`, `49469`).
 

--- a/README.md
+++ b/README.md
@@ -57,15 +57,17 @@ Set `profiles` to run several Hermes instances in the same add-on. Non-dotted na
 
 ```yaml
 profiles:
-  - .hermes              # primary, lives at /config/.hermes
-  - finance-ana          # /config/.hermes/profiles/finance-ana
+  - .hermes              # primary, kept as-is (leading "."): /config/.hermes
+  - amy                  # bare name, prefixed by profiles_base: /config/.hermes/profiles/amy
+  - bob                  # same: /config/.hermes/profiles/bob
 profile_env_vars:
-  - profile: finance-ana
+  # `profile` matches the entry above exactly (use the string you put in `profiles`).
+  - profile: amy
     name: OPENROUTER_API_KEY
-    value: finance-only-key
-  - profile: finance-ana
-    name: SOME_VAR
-    value: special
+    value: amy-only-key
+  - profile: amy
+    name: SOME_AMY_VAR
+    value: amy-special
 ```
 
 A single shared install at `~/.hermes/hermes-agent` (clone + venv) backs every profile — only the per-profile `.env`, `config.yaml`, `SOUL.md`, sessions, memories, and logs live under each profile's directory.

--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ A single shared install at `~/.hermes/hermes-agent` (clone + venv) backs every p
 
 The first entry is the **primary** — it keeps the existing root URLs (`/hermes/`, `/dashboard/`, `/terminal/`, `/v1/`). Each additional profile is exposed under `/profile/<name>/...`. Per-profile ports allocate from a base + index (`8642`, `49269`, `49369`, `49469`).
 
+**Upgrade note:** If you already used bare profile names with earlier multi-profile add-on versions, existing flat directories such as `/config/amy` are preserved automatically when the new `.hermes/profiles/amy` directory does not exist yet. To keep flat paths intentionally, set `profiles_base` to an empty string. To adopt the upstream-style layout, move the profile data to `/config/.hermes/profiles/<name>`.
+
 **Note:** Values added via `env_vars` are not removed or reset from `.env` when cleared or removed in the Home Assistant UI -- edit each profile's `.env` directly to remove them.
 
 Hermes-internal configuration (model, platforms, memory, tools) is managed via the terminal:
@@ -235,7 +237,7 @@ The default single-profile layout after a successful first start is:
 ├── .npm-global/               # npm global packages
 ├── .bash_aliases              # Custom aliases and functions (optional, user-created)
 ├── .bashrc                    # Shell config
-├── .hermes_install_hermes     # Install marker for the default .hermes profile
+├── .hermes_install            # Shared install marker for the Hermes clone + venv
 ├── .hermes_profile            # Env vars + PATH (regenerated)
 ├── .profile                   # Sources .bashrc (login shell init)
 └── .tmux.conf                 # tmux config

--- a/README.md
+++ b/README.md
@@ -46,20 +46,19 @@ Add-on-level options are configured in the Home Assistant UI (Settings > Apps > 
 | `env_vars`            | `OPENROUTER_API_KEY` (example)                     | Hermes .env variables — written to each profile's `.env` on each start          |
 | `hermes_home`         | `.hermes`                                          | Single-profile mode: agent profile directory (relative to ~). Ignored if `profiles` is non-empty |
 | `profiles`            | `[]`                                               | Multi-profile mode: list of profile directories run concurrently. First entry is the primary |
-| `profiles_base`       | `.hermes/profiles`                                 | Default parent dir for bare profile names. Entries containing `/` or starting with `.` are taken as-is. Set to empty to disable the prefix |
+| `profiles_base`       | `.hermes/profiles`                                 | Default parent dir for non-dotted profile names. Entries starting with `.` are taken as-is (legacy `.hermes` keeps working). Set to empty to disable the prefix |
 | `profile_env_vars`    | `[]`                                               | Per-profile `.env` overrides: each entry is `{profile, name, value}` where `profile` matches a directory in `profiles` |
 
 API keys can be configured in two places: `env_vars` above (convenient, via Home Assistant UI) or each profile's `.env` directly (full list, via terminal or `hermes setup`). Non-empty top-level `env_vars` are written to every profile's `.env` on each start, overriding existing entries. `profile_env_vars` entries layer on top of the top-level set for the profile whose directory matches `profile`.
 
 ### Running multiple profiles concurrently
 
-Set `profiles` to run several Hermes instances in the same add-on. Bare names are placed under `profiles_base` (default `.hermes/profiles`) to match upstream's [profile layout](https://hermes-agent.nousresearch.com/docs/user-guide/profiles); entries containing `/` or starting with `.` are taken as-is. Per-profile env overrides live in a flat `profile_env_vars` list (Home Assistant Supervisor only allows nested objects two levels deep):
+Set `profiles` to run several Hermes instances in the same add-on. Non-dotted names are placed under `profiles_base` (default `.hermes/profiles`) to match upstream's [profile layout](https://hermes-agent.nousresearch.com/docs/user-guide/profiles); entries starting with `.` are taken as-is. Per-profile env overrides live in a flat `profile_env_vars` list (Home Assistant Supervisor only allows nested objects two levels deep):
 
 ```yaml
 profiles:
   - .hermes              # primary, lives at /config/.hermes
   - finance-ana          # /config/.hermes/profiles/finance-ana
-  - team/coder           # /config/team/coder (already has a slash)
 profile_env_vars:
   - profile: finance-ana
     name: OPENROUTER_API_KEY

--- a/README.md
+++ b/README.md
@@ -133,10 +133,11 @@ Via Home Assistant host + docker exec, no SSH server in container required. Port
 ssh -p 22222 -t root@homeassistant.local "docker exec -it \$(docker ps -qf name=hermes_agent) bash"
 
 # Hermes (shared tmux session — same as Home Assistant sidebar "Hermes" tab)
-ssh -p 22222 -t root@homeassistant.local "docker exec -it \$(docker ps -qf name=hermes_agent) tmux -u new -A -s hermes /usr/local/bin/start-hermes"
+# Replace <profile> with the sanitized profile name (e.g. "hermes" for the primary `.hermes`, "amy" for `amy`).
+ssh -p 22222 -t root@homeassistant.local "docker exec -it \$(docker ps -qf name=hermes_agent) tmux -L hermes-<profile> -u new -A -s hermes-<profile> /usr/local/bin/start-hermes"
 
 # Terminal (shared tmux session — same as Home Assistant sidebar "Terminal" tab)
-ssh -p 22222 -t root@homeassistant.local "docker exec -it \$(docker ps -qf name=hermes_agent) tmux -u new -A -s terminal bash"
+ssh -p 22222 -t root@homeassistant.local "docker exec -it \$(docker ps -qf name=hermes_agent) tmux -L terminal-<profile> -u new -A -s terminal-<profile> bash"
 
 # Copy files (e.g. upload a custom SOUL.md — works even when add-on is stopped)
 scp -P 22222 SOUL.md "root@homeassistant.local:/mnt/data/supervisor/addon_configs/*hermes_agent/.hermes/"

--- a/hermes_agent/CHANGELOG.md
+++ b/hermes_agent/CHANGELOG.md
@@ -6,6 +6,20 @@ The format follows the spirit of [Keep a Changelog](https://keepachangelog.com/e
 
 ## [Unreleased]
 
+### Added
+
+- Add `profiles_base` so bare multi-profile names can default to upstream-style `.hermes/profiles/<name>` storage.
+
+### Changed
+
+- Use one shared Hermes Agent clone and virtualenv for all profiles instead of installing Hermes separately for every profile.
+- Preserve existing flat profile directories such as `/config/amy` during upgrades when the new `profiles_base` target does not exist yet.
+
+### Fixed
+
+- Fix the shared-install dashboard patch helper call so startup uses the shared `SRC_DIR` instead of removed per-profile variables.
+- Correct Home Assistant option text and storage documentation for the shared install and `profiles_base` behavior.
+
 ## [1.1.2] - 2026-06-15
 
 ### Added

--- a/hermes_agent/config.yaml
+++ b/hermes_agent/config.yaml
@@ -1,5 +1,5 @@
 name: Hermes Agent
-version: "1.1.0"
+version: "1.1.1"
 slug: hermes_agent
 description: "The self-improving AI agent built by Nous Research. Home Assistant add-on by Wolfram Ravenwolf."
 url: "https://github.com/WolframRavenwolf/hermes-ha-addon"
@@ -32,6 +32,7 @@ options:
   homeassistant_token: ""
   hermes_home: ".hermes"
   profiles: []
+  profiles_base: ".hermes/profiles"
   profile_env_vars: []
   enable_dashboard: false
   enable_terminal: false
@@ -50,6 +51,7 @@ schema:
   hermes_home: "str?"
   profiles:
     - "str"
+  profiles_base: "str?"
   profile_env_vars:
     - profile: "str"
       name: "match(^[A-Z_][A-Z0-9_]{0,254}$)"

--- a/hermes_agent/dashboard-patches.py
+++ b/hermes_agent/dashboard-patches.py
@@ -39,6 +39,12 @@ MODERN_BASE_FALLBACK_PATCH = (
     'export const HERMES_BASE_PATH = readBasePath() || HERMES_IMPORT_META_BASE_PATH;'
 )
 VITE_BASE_MARKER = "HA-ADDON-BASE-INJECTED"
+PREFIX_LIMIT_MARKER = "HA-ADDON-PREFIX-LIMIT-PATCHED"
+# HA Ingress prepends `/api/hassio_ingress/<32-char-token>` (~50 chars). Add a
+# nested addon path like `/profile/<name>/dashboard` and the total easily
+# exceeds upstream's default 64-char ceiling, causing the SPA serve handler to
+# skip the asset URL rewrite and the browser to 404 on `/assets/...`.
+PREFIX_LIMIT_RAISED = 256
 
 
 def read(path: Path) -> str:
@@ -185,6 +191,35 @@ def ensure_vite_relative_base(vite: Path, vite_text: str) -> bool:
     return False
 
 
+def patch_prefix_length_limit(prefix_py: Path, text: str) -> bool:
+    """Raise upstream's X-Forwarded-Prefix length ceiling for HA Ingress.
+
+    Upstream rejects prefixes longer than 64 characters as a header-injection
+    guard. HA Ingress' own token segment already eats most of that budget,
+    leaving no room for nested addon routes (`/profile/<name>/dashboard`).
+    """
+    if not prefix_py.is_file():
+        return False
+    if PREFIX_LIMIT_MARKER in text:
+        return False
+    patched, count = re.subn(
+        r"if len\(p\) > 64:",
+        f"if len(p) > {PREFIX_LIMIT_RAISED}:  # {PREFIX_LIMIT_MARKER}",
+        text,
+        count=1,
+    )
+    if not count:
+        print(
+            "[run] WARNING: prefix.py length check pattern changed upstream - "
+            "nested addon routes (/profile/...) may 404 on dashboard assets"
+        )
+        return False
+    if write_if_changed(prefix_py, text, patched):
+        print("[run] Patched dashboard prefix length limit for HA Ingress")
+        return True
+    return False
+
+
 def main() -> int:
     if len(sys.argv) != 3:
         print("usage: dashboard-patches.py SRC_DIR STATUS_FILE", file=sys.stderr)
@@ -196,6 +231,7 @@ def main() -> int:
     plugins = src / "web/src/plugins/usePlugins.ts"
     main_tsx = src / "web/src/main.tsx"
     vite = src / "web/vite.config.ts"
+    prefix_py = src / "hermes_cli/dashboard_auth/prefix.py"
 
     changed = False
     api_text = read(api)
@@ -208,6 +244,7 @@ def main() -> int:
         changed |= patch_legacy_plugins(plugins, read(plugins))
         changed |= patch_legacy_router(main_tsx, read(main_tsx))
     changed |= ensure_vite_relative_base(vite, read(vite))
+    changed |= patch_prefix_length_limit(prefix_py, read(prefix_py))
 
     status_file.write_text("changed" if changed else "")
     return 0

--- a/hermes_agent/profile-init.sh
+++ b/hermes_agent/profile-init.sh
@@ -82,6 +82,15 @@ resolve_profiles() {
     dir="${PROFILE_DIRS[$i]}"
     if [ "$profiles_from_list" = "true" ]; then
       effective_dir="$(_resolve_profile_dir "$dir" "$base")"
+      case "$dir" in
+        .*) ;;
+        *)
+          if [ -n "$base" ] && [ -d "$HOME/$dir" ] && [ ! -e "$HOME/$effective_dir" ]; then
+            echo "[profile-init] WARNING: using existing legacy profile directory '$dir' instead of '$effective_dir'; migrate the profile data or set profiles_base to empty to keep flat paths intentionally" >&2
+            effective_dir="$dir"
+          fi
+          ;;
+      esac
     else
       effective_dir="$dir"
     fi

--- a/hermes_agent/profile-init.sh
+++ b/hermes_agent/profile-init.sh
@@ -43,10 +43,9 @@ sanitize_profile_name() {
 }
 
 # Resolve a `profiles[]` entry into its on-disk relative directory.
-# Bare names (no `/`, no leading `.`) are placed under PROFILES_BASE so users
-# can write `finance-ana` instead of `.hermes/profiles/finance-ana`.
-# Entries containing `/` or starting with `.` are kept as-is so existing
-# layouts (e.g. `.hermes`, `team/finance`) continue to work.
+# Bare names (no leading `.`) are placed under PROFILES_BASE so users can write
+# `finance-ana` instead of `.hermes/profiles/finance-ana`. Entries starting
+# with `.` are kept as-is so the legacy `.hermes` path keeps working.
 _resolve_profile_dir() {
   local raw="$1" base="$2"
   if [ -z "$base" ]; then
@@ -54,7 +53,7 @@ _resolve_profile_dir() {
     return
   fi
   case "$raw" in
-    */* | .*) printf '%s' "$raw" ;;
+    .*) printf '%s' "$raw" ;;
     *) printf '%s/%s' "$base" "$raw" ;;
   esac
 }

--- a/hermes_agent/profile-init.sh
+++ b/hermes_agent/profile-init.sh
@@ -7,14 +7,13 @@
 # Reads from caller env:
 #   OPTIONS_FILE          path to HA add-on options.json
 #   HERMES_HOME_DIR       legacy single-profile fallback (string, may be empty)
-#   HOME                  user home (per-profile homes are $HOME/<dir>)
+#   PROFILES_BASE         default-base for bare profile names (default ".hermes/profiles")
+#   HOME                  user home (per-profile homes are $HOME/<effective_dir>)
 #
 # Populates arrays in the caller's scope:
 #   PROFILE_DIRS[]        raw "home" string per profile
 #   PROFILE_NAMES[]       sanitized identifier per profile (alnum + _)
 #   PROFILE_HOMES[]       $HOME/<dir>
-#   PROFILE_SRC_DIRS[]    <home>/hermes-agent
-#   PROFILE_VENV_DIRS[]   <src_dir>/venv
 #   PROFILE_PATH_PREFIX[] "" for primary, "/profile/<name>" otherwise
 #   PROFILE_MARKER[]      install-marker file per profile
 #   API_PORTS[]           per-profile gateway API server port
@@ -43,28 +42,50 @@ sanitize_profile_name() {
   printf '%s' "$name"
 }
 
+# Resolve a `profiles[]` entry into its on-disk relative directory.
+# Bare names (no `/`, no leading `.`) are placed under PROFILES_BASE so users
+# can write `finance-ana` instead of `.hermes/profiles/finance-ana`.
+# Entries containing `/` or starting with `.` are kept as-is so existing
+# layouts (e.g. `.hermes`, `team/finance`) continue to work.
+_resolve_profile_dir() {
+  local raw="$1" base="$2"
+  if [ -z "$base" ]; then
+    printf '%s' "$raw"
+    return
+  fi
+  case "$raw" in
+    */* | .*) printf '%s' "$raw" ;;
+    *) printf '%s/%s' "$base" "$raw" ;;
+  esac
+}
+
 # Read the profiles list (or legacy hermes_home) and populate all PROFILE_* + port arrays.
 resolve_profiles() {
   PROFILE_DIRS=()
-
   local _line
+  local profiles_from_list=true
   while IFS= read -r _line; do
     [ -n "$_line" ] && PROFILE_DIRS+=("$_line")
   done < <(jq -r '.profiles[]? // empty' "$OPTIONS_FILE")
   if [ "${#PROFILE_DIRS[@]}" -eq 0 ]; then
     PROFILE_DIRS=("${HERMES_HOME_DIR:-.hermes}")
+    profiles_from_list=false
   fi
 
   PROFILE_NAMES=()
   PROFILE_HOMES=()
-  PROFILE_SRC_DIRS=()
-  PROFILE_VENV_DIRS=()
   PROFILE_PATH_PREFIX=()
   PROFILE_MARKER=()
 
-  local i j dir name
+  local i j dir effective_dir name
+  local base="${PROFILES_BASE-.hermes/profiles}"
   for i in "${!PROFILE_DIRS[@]}"; do
     dir="${PROFILE_DIRS[$i]}"
+    if [ "$profiles_from_list" = "true" ]; then
+      effective_dir="$(_resolve_profile_dir "$dir" "$base")"
+    else
+      effective_dir="$dir"
+    fi
     name="$(sanitize_profile_name "$dir")"
     if [ -z "$name" ]; then
       echo "[profile-init] FATAL: profile dir '$dir' yields empty name after sanitization" >&2
@@ -77,9 +98,7 @@ resolve_profiles() {
       fi
     done
     PROFILE_NAMES[i]="$name"
-    PROFILE_HOMES[i]="$HOME/$dir"
-    PROFILE_SRC_DIRS[i]="${PROFILE_HOMES[$i]}/hermes-agent"
-    PROFILE_VENV_DIRS[i]="${PROFILE_SRC_DIRS[$i]}/venv"
+    PROFILE_HOMES[i]="$HOME/$effective_dir"
     if [ "$i" -eq 0 ]; then
       PROFILE_PATH_PREFIX[i]=""
     else

--- a/hermes_agent/run.sh
+++ b/hermes_agent/run.sh
@@ -24,7 +24,10 @@ HASS_TOKEN=$(opt homeassistant_token)
 # shellcheck disable=SC2034  # consumed by resolve_profiles in profile-init.sh
 HERMES_HOME_DIR=$(opt hermes_home)
 # shellcheck disable=SC2034  # consumed by resolve_profiles in profile-init.sh
-PROFILES_BASE=$(opt profiles_base)
+# Preserve the documented default even when upgrading from an options.json that
+# predates profiles_base, while still allowing an explicit empty value to keep
+# legacy flat profile directories.
+PROFILES_BASE=$(jq -r 'if has("profiles_base") then (.profiles_base // "") else ".hermes/profiles" end' "$OPTIONS_FILE")
 ENABLE_DASHBOARD=$(opt_bool enable_dashboard)
 ENABLE_TERMINAL=$(opt_bool enable_terminal)
 ENABLE_API=$(opt_bool enable_api)
@@ -317,8 +320,8 @@ install_hermes_core() {
         local status_file
         status_file="$(mktemp)"
 
-        if ! /usr/local/bin/hermes-dashboard-patches "$src_dir" "$status_file"; then
-            echo "[run] [$name] WARNING: dashboard compatibility patch failed - continuing startup"
+        if ! /usr/local/bin/hermes-dashboard-patches "$SRC_DIR" "$status_file"; then
+            echo "[run] WARNING: dashboard compatibility patch failed - continuing startup"
         fi
         if [ -s "$status_file" ]; then
             rebuild="true"

--- a/hermes_agent/run.sh
+++ b/hermes_agent/run.sh
@@ -656,13 +656,17 @@ start_ttyd_for_profile() {
     local term_port="${TTYD_TERMINAL_PORTS[$i]}"
 
     echo "[run] [$name] Starting ttyd (hermes: $hermes_port, terminal: $term_port)..."
+    # tmux server env is captured on first new-session and shared by every
+    # later session on the same socket. With one shared socket, profile-N's
+    # session would inherit profile-0's HERMES_HOME. Use a per-profile
+    # socket (`-L`) so each tmux server inherits the right env.
     env HERMES_HOME="$home" \
         ttyd \
             --port "$hermes_port" \
             --interface 127.0.0.1 \
             --base-path "${prefix}/hermes/" \
             --writable -d 3 \
-            tmux -u new -A -s "hermes-${name}" /usr/local/bin/start-hermes &
+            tmux -L "hermes-${name}" -u new -A -s "hermes-${name}" /usr/local/bin/start-hermes &
     TTYD_HERMES_PIDS[$i]=$!
 
     env HERMES_HOME="$home" \
@@ -671,7 +675,7 @@ start_ttyd_for_profile() {
             --interface 127.0.0.1 \
             --base-path "${prefix}/terminal/" \
             --writable -d 3 \
-            tmux -u new -A -s "terminal-${name}" /usr/bin/bash &
+            tmux -L "terminal-${name}" -u new -A -s "terminal-${name}" /usr/bin/bash &
     TTYD_TERMINAL_PIDS[$i]=$!
     echo "[run] [$name] ttyd PIDs: hermes=${TTYD_HERMES_PIDS[$i]} terminal=${TTYD_TERMINAL_PIDS[$i]}"
 }

--- a/hermes_agent/run.sh
+++ b/hermes_agent/run.sh
@@ -23,6 +23,8 @@ HASS_URL=$(opt hass_url)
 HASS_TOKEN=$(opt homeassistant_token)
 # shellcheck disable=SC2034  # consumed by resolve_profiles in profile-init.sh
 HERMES_HOME_DIR=$(opt hermes_home)
+# shellcheck disable=SC2034  # consumed by resolve_profiles in profile-init.sh
+PROFILES_BASE=$(opt profiles_base)
 ENABLE_DASHBOARD=$(opt_bool enable_dashboard)
 ENABLE_TERMINAL=$(opt_bool enable_terminal)
 ENABLE_API=$(opt_bool enable_api)
@@ -70,7 +72,6 @@ source "$PROFILE_INIT_LIB"
 resolve_profiles || exit 1
 
 PRIMARY_HOME="${PROFILE_HOMES[0]}"
-PRIMARY_VENV_DIR="${PROFILE_VENV_DIRS[0]}"
 export HERMES_HOME="$PRIMARY_HOME"
 
 echo "[run] Profiles (${#PROFILE_DIRS[@]}):"
@@ -218,38 +219,40 @@ PROFILE
     echo "[run] Created default .profile"
 fi
 
-# ── Section 5: Hermes installation (per profile) ─────────────────────
+# ── Section 5: Hermes installation (single shared install) ───────────
+# Upstream Hermes itself supports multiple profiles via per-profile HERMES_HOME
+# directories (see https://hermes-agent.nousresearch.com/docs/user-guide/profiles).
+# We therefore install one shared clone + venv and point each profile's
+# HERMES_HOME at its own data directory at gateway start time.
+SRC_DIR="$HOME/.hermes/hermes-agent"
+VENV_DIR="$SRC_DIR/venv"
+MARKER_FILE="$HOME/.hermes_install"
+
 compute_marker() {
-    local src_dir="$1"
-    local ref="${GIT_REF:-$(cd "$src_dir" 2>/dev/null && git rev-parse --abbrev-ref HEAD 2>/dev/null || echo unknown)}"
+    local ref="${GIT_REF:-$(cd "$SRC_DIR" 2>/dev/null && git rev-parse --abbrev-ref HEAD 2>/dev/null || echo unknown)}"
     local hash
-    hash="$(cd "$src_dir" 2>/dev/null && git rev-parse HEAD 2>/dev/null || echo none)"
+    hash="$(cd "$SRC_DIR" 2>/dev/null && git rev-parse HEAD 2>/dev/null || echo none)"
     local subs
-    subs="$(find "$src_dir" -mindepth 2 -maxdepth 2 -name pyproject.toml -print 2>/dev/null | while IFS= read -r pyproject; do basename "$(dirname "$pyproject")"; done | sort | paste -sd,)"
+    subs="$(find "$SRC_DIR" -mindepth 2 -maxdepth 2 -name pyproject.toml -print 2>/dev/null | while IFS= read -r pyproject; do basename "$(dirname "$pyproject")"; done | sort | paste -sd,)"
     echo "${GIT_URL}|${ref}|${hash}|${subs}"
 }
 
 install_needed() {
-    local src_dir="$1" venv_dir="$2" marker_file="$3"
     local current
-    current=$(compute_marker "$src_dir")
-    if [ ! -f "$marker_file" ]; then return 0; fi
-    if [ "$(cat "$marker_file")" != "$current" ]; then return 0; fi
-    if [ ! -f "$venv_dir/bin/activate" ]; then return 0; fi
-    if [ ! -f "$venv_dir/bin/hermes" ]; then return 0; fi
+    current=$(compute_marker)
+    if [ ! -f "$MARKER_FILE" ]; then return 0; fi
+    if [ "$(cat "$MARKER_FILE")" != "$current" ]; then return 0; fi
+    if [ ! -f "$VENV_DIR/bin/activate" ]; then return 0; fi
+    if [ ! -f "$VENV_DIR/bin/hermes" ]; then return 0; fi
     return 1
 }
 
-install_profile() {
-    local i="$1"
-    local src_dir="${PROFILE_SRC_DIRS[$i]}"
-    local venv_dir="${PROFILE_VENV_DIRS[$i]}"
-    local marker_file="${PROFILE_MARKER[$i]}"
-    local name="${PROFILE_NAMES[$i]}"
+install_hermes_core() {
+    mkdir -p "$(dirname "$SRC_DIR")"
 
     # Clone if missing
-    if [ ! -d "$src_dir/.git" ]; then
-        echo "[run] [$name] Cloning Hermes Agent..."
+    if [ ! -d "$SRC_DIR/.git" ]; then
+        echo "[run] Cloning Hermes Agent..."
         local clone_url="$GIT_URL"
         if [ -n "$GIT_TOKEN" ]; then
             clone_url=$(echo "$GIT_URL" | sed "s|https://|https://${GIT_TOKEN}@|")
@@ -258,95 +261,93 @@ install_profile() {
         if [ -n "$GIT_REF" ]; then
             clone_args+=(--branch "$GIT_REF")
         fi
-        git clone "${clone_args[@]}" "$clone_url" "$src_dir"
-        (cd "$src_dir" && git submodule update --init --recursive 2>/dev/null || true)
-        echo "[run] [$name] Clone complete: $(cd "$src_dir" && git log --oneline -1)"
+        git clone "${clone_args[@]}" "$clone_url" "$SRC_DIR"
+        (cd "$SRC_DIR" && git submodule update --init --recursive 2>/dev/null || true)
+        echo "[run] Clone complete: $(cd "$SRC_DIR" && git log --oneline -1)"
     fi
 
     # Auto-update (stash local changes, pull, restore)
-    if [ "$AUTO_UPDATE" = "true" ] && [ -d "$src_dir/.git" ]; then
-        echo "[run] [$name] Pulling latest changes..."
+    if [ "$AUTO_UPDATE" = "true" ] && [ -d "$SRC_DIR/.git" ]; then
+        echo "[run] Pulling latest changes..."
         (
-            cd "$src_dir"
+            cd "$SRC_DIR"
             git stash --quiet 2>/dev/null || true
-            git pull --ff-only 2>/dev/null || echo "[run] [$name] Warning: git pull failed (branch may have diverged)"
+            git pull --ff-only 2>/dev/null || echo "[run] Warning: git pull failed (branch may have diverged)"
             git stash pop --quiet 2>/dev/null || true
             git submodule update --init --recursive 2>/dev/null || true
         )
     fi
 
     # Editable install
-    if [ ! -f "$venv_dir/bin/activate" ]; then
-        echo "[run] [$name] Creating venv..."
-        uv venv "$venv_dir" --python 3.11
+    if [ ! -f "$VENV_DIR/bin/activate" ]; then
+        echo "[run] Creating venv..."
+        uv venv "$VENV_DIR" --python 3.11
     fi
-    if install_needed "$src_dir" "$venv_dir" "$marker_file"; then
-        echo "[run] [$name] Installing Hermes (editable)..."
+    if install_needed; then
+        echo "[run] Installing Hermes (editable)..."
         (
-            cd "$src_dir"
+            cd "$SRC_DIR"
             # shellcheck disable=SC1091
-            source "$venv_dir/bin/activate"
+            source "$VENV_DIR/bin/activate"
             uv pip install -e ".[all,dev]" 2>&1 | tail -5
-            if [ -f "$src_dir/mini-swe-agent/pyproject.toml" ]; then
-                uv pip install -e "$src_dir/mini-swe-agent" 2>&1 | tail -3
+            if [ -f "$SRC_DIR/mini-swe-agent/pyproject.toml" ]; then
+                uv pip install -e "$SRC_DIR/mini-swe-agent" 2>&1 | tail -3
             fi
-            if [ -f "$src_dir/tinker-atropos/pyproject.toml" ]; then
-                uv pip install -e "$src_dir/tinker-atropos" 2>&1 | tail -3
+            if [ -f "$SRC_DIR/tinker-atropos/pyproject.toml" ]; then
+                uv pip install -e "$SRC_DIR/tinker-atropos" 2>&1 | tail -3
             fi
         )
-        compute_marker "$src_dir" > "$marker_file"
-        echo "[run] [$name] Install complete"
+        compute_marker > "$MARKER_FILE"
+        echo "[run] Install complete"
     else
-        echo "[run] [$name] Install up to date (marker match)"
+        echo "[run] Install up to date (marker match)"
     fi
 
     # Link image-installed npm packages into project node_modules
-    if [ ! -e "$src_dir/node_modules/agent-browser" ]; then
-        mkdir -p "$src_dir/node_modules"
-        ln -snf /usr/lib/node_modules/agent-browser "$src_dir/node_modules/agent-browser"
-        (cd "$src_dir" && npm audit fix --silent 2>/dev/null || true)
-        echo "[run] [$name] Linked agent-browser into project"
+    if [ ! -e "$SRC_DIR/node_modules/agent-browser" ]; then
+        mkdir -p "$SRC_DIR/node_modules"
+        ln -snf /usr/lib/node_modules/agent-browser "$SRC_DIR/node_modules/agent-browser"
+        (cd "$SRC_DIR" && npm audit fix --silent 2>/dev/null || true)
+        echo "[run] Linked agent-browser into project"
     fi
 
-    # Build dashboard web frontend
-    if [ -f "$src_dir/web/package.json" ]; then
+    # Build dashboard web frontend (single build, shared by every profile)
+    if [ -f "$SRC_DIR/web/package.json" ]; then
         local rebuild="false"
         local status_file
         status_file="$(mktemp)"
 
-        if ! python /usr/local/bin/hermes-dashboard-patches "$src_dir" "$status_file"; then
-            echo "[run] [$name] WARNING: dashboard compatibility patch failed - continuing startup"
+        if ! python /usr/local/bin/hermes-dashboard-patches "$SRC_DIR" "$status_file"; then
+            echo "[run] WARNING: dashboard compatibility patch failed - continuing startup"
         fi
         if [ -s "$status_file" ]; then
             rebuild="true"
         fi
         rm -f "$status_file"
 
-        if grep -Eq '(src|href)="/assets/' "$src_dir/hermes_cli/web_dist/index.html" 2>/dev/null; then
+        if grep -Eq '(src|href)="/assets/' "$SRC_DIR/hermes_cli/web_dist/index.html" 2>/dev/null; then
             rebuild="true"
         fi
 
-        if [ "$rebuild" = "true" ] || [ ! -d "$src_dir/hermes_cli/web_dist/assets" ]; then
-            echo "[run] [$name] Building dashboard frontend..."
-            if (cd "$src_dir/web" && npm install --silent 2>&1 | tail -3 && npx vite build --outDir ../hermes_cli/web_dist --emptyOutDir 2>&1 | tail -3); then
-                echo "[run] [$name] Dashboard frontend built"
+        if [ "$rebuild" = "true" ] || [ ! -d "$SRC_DIR/hermes_cli/web_dist/assets" ]; then
+            echo "[run] Building dashboard frontend..."
+            if (cd "$SRC_DIR/web" && npm install --silent 2>&1 | tail -3 && npx vite build --outDir ../hermes_cli/web_dist --emptyOutDir 2>&1 | tail -3); then
+                echo "[run] Dashboard frontend built"
             else
-                echo "[run] [$name] Warning: dashboard frontend build failed (dashboard will not be available)"
+                echo "[run] Warning: dashboard frontend build failed (dashboard will not be available)"
             fi
         fi
     fi
 }
 
-for i in "${!PROFILE_DIRS[@]}"; do
-    install_profile "$i"
-done
+install_hermes_core
 
-# Activate the primary profile's venv for any tooling (e.g. dashboard module probe).
+# Activate the shared venv for any tooling (e.g. dashboard module probe).
 # shellcheck disable=SC1091
-source "$PRIMARY_VENV_DIR/bin/activate"
+source "$VENV_DIR/bin/activate"
 
-# Verify version (from primary)
-HERMES_VERSION="$("$PRIMARY_VENV_DIR/bin/hermes" --version 2>/dev/null | head -1 || echo "unknown")"
+# Verify version
+HERMES_VERSION="$("$VENV_DIR/bin/hermes" --version 2>/dev/null | head -1 || echo "unknown")"
 export HERMES_VERSION
 echo "[run] Hermes version: $HERMES_VERSION"
 
@@ -354,16 +355,15 @@ echo "[run] Hermes version: $HERMES_VERSION"
 scaffold_profile_files() {
     local i="$1"
     local home="${PROFILE_HOMES[$i]}"
-    local src_dir="${PROFILE_SRC_DIRS[$i]}"
     local name="${PROFILE_NAMES[$i]}"
 
-    if [ ! -f "$home/.env" ] && [ -f "$src_dir/.env.example" ]; then
-        cp -p "$src_dir/.env.example" "$home/.env"
+    if [ ! -f "$home/.env" ] && [ -f "$SRC_DIR/.env.example" ]; then
+        cp -p "$SRC_DIR/.env.example" "$home/.env"
         chmod 600 "$home/.env"
         echo "[run] [$name] Created .env from source example (chmod 600)"
     fi
-    if [ ! -f "$home/config.yaml" ] && [ -f "$src_dir/cli-config.yaml.example" ]; then
-        cp -p "$src_dir/cli-config.yaml.example" "$home/config.yaml"
+    if [ ! -f "$home/config.yaml" ] && [ -f "$SRC_DIR/cli-config.yaml.example" ]; then
+        cp -p "$SRC_DIR/cli-config.yaml.example" "$home/config.yaml"
         echo "[run] [$name] Created config.yaml from source example"
     fi
     if [ ! -f "$home/SOUL.md" ]; then
@@ -447,7 +447,7 @@ export HOMEBREW_CELLAR="$BREW_DIR/Cellar"
 export HOMEBREW_PREFIX="$BREW_DIR"
 export HOMEBREW_REPOSITORY="$BREW_DIR/Homebrew"
 export NPM_CONFIG_PREFIX="$NODE_DIR"
-export PATH="\${HERMES_HOME}/hermes-agent/venv/bin:$BREW_DIR/sbin:$BREW_DIR/bin:$GO_DIR/bin:/usr/local/go/bin:$NODE_DIR/bin:\$PATH"
+export PATH="$VENV_DIR/bin:$BREW_DIR/sbin:$BREW_DIR/bin:$GO_DIR/bin:/usr/local/go/bin:$NODE_DIR/bin:\$PATH"
 ENVSH
 
 # ── Section 8: TLS certificates (shared) ─────────────────────────────
@@ -474,7 +474,7 @@ fi
 
 # ── Section 9: Render nginx config ───────────────────────────────────
 DASHBOARD_AVAILABLE="false"
-if "$PRIMARY_VENV_DIR/bin/python" -c "from hermes_cli.web_server import start_server" 2>/dev/null; then
+if "$VENV_DIR/bin/python" -c "from hermes_cli.web_server import start_server" 2>/dev/null; then
     DASHBOARD_AVAILABLE="true"
 fi
 
@@ -601,7 +601,6 @@ DASHBOARD_PIDS=()
 start_gateway_for_profile() {
     local i="$1"
     local home="${PROFILE_HOMES[$i]}"
-    local venv="${PROFILE_VENV_DIRS[$i]}"
     local name="${PROFILE_NAMES[$i]}"
     local port="${API_PORTS[$i]}"
 
@@ -610,8 +609,8 @@ start_gateway_for_profile() {
     (
         cd "$home"
         export HERMES_HOME="$home"
-        export PATH="$venv/bin:$BASE_PATH"
-        "$venv/bin/hermes" gateway run 2>&1 | tee -a "$home/logs/gateway.log"
+        export PATH="$VENV_DIR/bin:$BASE_PATH"
+        "$VENV_DIR/bin/hermes" gateway run 2>&1 | tee -a "$home/logs/gateway.log"
     ) &
     local tee_pid=$!
     sleep 0.5
@@ -680,7 +679,6 @@ start_ttyd_for_profile() {
 start_dashboard_for_profile() {
     local i="$1"
     local home="${PROFILE_HOMES[$i]}"
-    local venv="${PROFILE_VENV_DIRS[$i]}"
     local name="${PROFILE_NAMES[$i]}"
     local port="${DASHBOARD_PORTS[$i]}"
 
@@ -692,7 +690,7 @@ start_dashboard_for_profile() {
     (
         cd "$home"
         export HERMES_HOME="$home"
-        exec "$venv/bin/python" -c "from hermes_cli.web_server import start_server; start_server(host='127.0.0.1', port=${port}, open_browser=False)"
+        exec "$VENV_DIR/bin/python" -c "from hermes_cli.web_server import start_server; start_server(host='127.0.0.1', port=${port}, open_browser=False)"
     ) &
     DASHBOARD_PIDS[$i]=$!
     echo "[run] [$name] Dashboard PID: ${DASHBOARD_PIDS[$i]}"

--- a/hermes_agent/translations/en.yaml
+++ b/hermes_agent/translations/en.yaml
@@ -45,7 +45,7 @@ configuration:
   env_vars:
     name: Hermes .env Variables
     description: >-
-      Written to ~/.hermes/.env on each start.
+      Written to each resolved profile's .env on each start.
       Use for API keys (e.g. OPENROUTER_API_KEY).
       Non-empty values override existing .env entries.
   hermes_home:
@@ -59,7 +59,8 @@ configuration:
     description: >-
       List of profile directories (relative to /config) to run concurrently.
       Bare names are placed under "profiles_base" (default .hermes/profiles).
-      Entries containing "/" or starting with "." are used as-is.
+      Non-dotted entries containing "/" are also placed under "profiles_base".
+      Entries starting with "." are used as-is.
       The first entry is the primary and keeps the root routes (/hermes/,
       /dashboard/, /v1/, /terminal/). Each additional profile is served under
       /profile/<name>/...

--- a/hermes_agent/translations/en.yaml
+++ b/hermes_agent/translations/en.yaml
@@ -58,9 +58,17 @@ configuration:
     name: Profiles (multi-profile mode)
     description: >-
       List of profile directories (relative to /config) to run concurrently.
+      Bare names are placed under "profiles_base" (default .hermes/profiles).
+      Entries containing "/" or starting with "." are used as-is.
       The first entry is the primary and keeps the root routes (/hermes/,
       /dashboard/, /v1/, /terminal/). Each additional profile is served under
       /profile/<name>/...
+  profiles_base:
+    name: Profiles Base Directory
+    description: >-
+      Default parent directory for bare profile names (default ".hermes/profiles",
+      matching upstream Hermes' convention). Set to empty to disable the prefix
+      and keep all profile dirs directly under /config/.
   profile_env_vars:
     name: Per-profile .env Overrides
     description: >-

--- a/tests/test_dashboard_ingress_patches.py
+++ b/tests/test_dashboard_ingress_patches.py
@@ -372,6 +372,42 @@ class DashboardIngressPatchTests(unittest.TestCase):
             self.assertIn('basename={BASE || "/"}', (src / "web/src/main.tsx").read_text())
             self.assertIn('base: "./"', (src / "web/vite.config.ts").read_text())
 
+    def test_prefix_length_limit_raised_for_ha_ingress(self) -> None:
+        """Upstream's normalise_prefix rejects > 64-char prefixes, which kills
+        nested addon routes (HA Ingress token + /profile/<name>/dashboard).
+        Patch must bump the limit."""
+        with tempfile.TemporaryDirectory() as tmp:
+            src = Path(tmp)
+            write_modern_dashboard_fixture(src)
+            prefix_py = src / "hermes_cli/dashboard_auth/prefix.py"
+            prefix_py.parent.mkdir(parents=True)
+            prefix_py.write_text(
+                "def normalise_prefix(raw):\n"
+                '    p = "/" + (raw or "").strip("/")\n'
+                '    if len(p) > 64:\n'
+                '        return ""\n'
+                "    return p\n"
+            )
+            status = src / "status"
+
+            result = run_dashboard_patches(src, status)
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual(status.read_text(), "changed")
+            patched = prefix_py.read_text()
+            self.assertIn("HA-ADDON-PREFIX-LIMIT-PATCHED", patched)
+            self.assertNotIn("if len(p) > 64:", patched)
+            # New limit must accommodate HA Ingress token (~50) +
+            # `/profile/<name>/dashboard` (up to ~50) comfortably.
+            self.assertIn("> 256:", patched)
+
+            # Idempotent on second run.
+            second_status = src / "status2"
+            second_result = run_dashboard_patches(src, second_status)
+            self.assertEqual(second_result.returncode, 0, second_result.stderr)
+            # Re-running with no other changes leaves status empty.
+            self.assertEqual(second_status.read_text(), "")
+
     def test_run_script_rebuilds_any_dashboard_with_absolute_index_assets(self) -> None:
         """Absolute Vite index assets are stale for HA Ingress, modern or legacy."""
         run_sh = RUN_SH.read_text()

--- a/tests/test_dashboard_ingress_patches.py
+++ b/tests/test_dashboard_ingress_patches.py
@@ -237,13 +237,13 @@ class DashboardIngressPatchTests(unittest.TestCase):
         # The gateway is started inside a subshell whose stdout pipes through tee
         # to a per-profile log file. The pipe lives inside `(...)` and the whole
         # group is backgrounded with `&`.
-        self.assertIn('"$venv/bin/hermes" gateway run 2>&1 | tee -a "$home/logs/gateway.log"', run_sh)
+        self.assertIn('"$VENV_DIR/bin/hermes" gateway run 2>&1 | tee -a "$home/logs/gateway.log"', run_sh)
 
     def test_install_marker_submodule_scan_tolerates_empty_matches(self) -> None:
         """The marker calculation must not call basename with no operands."""
         run_sh = RUN_SH.read_text()
 
-        self.assertIn('find "$src_dir" -mindepth 2 -maxdepth 2 -name pyproject.toml', run_sh)
+        self.assertIn('find "$SRC_DIR" -mindepth 2 -maxdepth 2 -name pyproject.toml', run_sh)
         self.assertNotIn("xargs -n1 basename", run_sh)
 
     def test_modern_dashboard_adds_import_meta_fallback_and_relative_vite_base(self) -> None:

--- a/tests/test_dashboard_ingress_patches.py
+++ b/tests/test_dashboard_ingress_patches.py
@@ -245,10 +245,19 @@ class DashboardIngressPatchTests(unittest.TestCase):
         run_sh = RUN_SH.read_text()
 
         self.assertIn("hermes-dashboard-patches", run_sh)
-        self.assertIn('/usr/local/bin/hermes-dashboard-patches "$src_dir" "$status_file"', run_sh)
+        self.assertIn('/usr/local/bin/hermes-dashboard-patches "$SRC_DIR" "$status_file"', run_sh)
+        self.assertNotIn('hermes-dashboard-patches "$src_dir"', run_sh)
         self.assertNotIn("python /usr/local/bin/hermes-dashboard-patches", run_sh)
         self.assertNotIn("BASE ||", run_sh)
         self.assertNotIn("HA-ADDON-ROUTER-BASENAME-PATCHED", run_sh)
+
+    def test_run_script_preserves_profiles_base_default_when_option_missing(self) -> None:
+        """Upgrades from older options.json should still get the documented default."""
+        run_sh = RUN_SH.read_text()
+
+        self.assertIn('has("profiles_base")', run_sh)
+        self.assertIn('else ".hermes/profiles"', run_sh)
+        self.assertNotIn("PROFILES_BASE=$(opt profiles_base)", run_sh)
 
     def test_run_script_keeps_gateway_in_foreground_under_ha_s6(self) -> None:
         """The add-on wrapper, not upstream Hermes' s6 manager, supervises the gateway."""

--- a/tests/test_multi_profile.py
+++ b/tests/test_multi_profile.py
@@ -151,13 +151,13 @@ class ProfileResolutionTests(unittest.TestCase):
         self.assertEqual(rows[0]["home"], f"{home}/.hermes")
         self.assertEqual(rows[1]["home"], f"{home}/.hermes/profiles/manual")
 
-    def test_entry_with_slash_preserved_as_is(self):
-        """Entries containing `/` are taken verbatim (already a relative subpath)."""
+    def test_entry_with_slash_is_also_prefixed(self):
+        """Non-dotted entries always go under profiles_base, even if they contain `/`."""
         res = _run_resolve({"profiles": ["primary", "team/finance"]})
         home = res["home"]
         rows = res["rows"]
         self.assertEqual(rows[0]["home"], f"{home}/.hermes/profiles/primary")
-        self.assertEqual(rows[1]["home"], f"{home}/team/finance")
+        self.assertEqual(rows[1]["home"], f"{home}/.hermes/profiles/team/finance")
 
     def test_profiles_base_empty_disables_prefix(self):
         """Empty PROFILES_BASE preserves the pre-feature layout (`/config/<name>`)."""

--- a/tests/test_multi_profile.py
+++ b/tests/test_multi_profile.py
@@ -27,7 +27,7 @@ BASH = "/bin/bash" if sys.platform == "darwin" and os.path.exists("/bin/bash") e
 
 # ── A. resolve_profiles ──────────────────────────────────────────────
 
-def _run_resolve(options_json, *, legacy_hermes_home="", home_base=None, profiles_base=None):
+def _run_resolve(options_json, *, legacy_hermes_home="", home_base=None, profiles_base=None, existing_dirs=None):
     """Run resolve_profiles, return either {'rows': [...]} or {'error': '...'}.
 
     profiles_base: None → inherit profile-init default (`.hermes/profiles`).
@@ -38,6 +38,8 @@ def _run_resolve(options_json, *, legacy_hermes_home="", home_base=None, profile
         if home_base is None:
             home_base = tmp_path / "home"
             home_base.mkdir()
+        for existing in existing_dirs or []:
+            (home_base / existing).mkdir(parents=True, exist_ok=True)
         options_path = tmp_path / "options.json"
         options_path.write_text(json.dumps(options_json))
         export_profiles_base = (
@@ -162,6 +164,12 @@ class ProfileResolutionTests(unittest.TestCase):
     def test_profiles_base_empty_disables_prefix(self):
         """Empty PROFILES_BASE preserves the pre-feature layout (`/config/<name>`)."""
         res = _run_resolve({"profiles": ["amy"]}, profiles_base="")
+        home = res["home"]
+        self.assertEqual(res["rows"][0]["home"], f"{home}/amy")
+
+    def test_existing_flat_profile_dir_is_preserved_on_upgrade(self):
+        """Existing pre-profiles_base profile dirs must not silently move."""
+        res = _run_resolve({"profiles": ["amy"]}, existing_dirs=["amy"])
         home = res["home"]
         self.assertEqual(res["rows"][0]["home"], f"{home}/amy")
 

--- a/tests/test_multi_profile.py
+++ b/tests/test_multi_profile.py
@@ -27,8 +27,12 @@ BASH = "/bin/bash" if sys.platform == "darwin" and os.path.exists("/bin/bash") e
 
 # ── A. resolve_profiles ──────────────────────────────────────────────
 
-def _run_resolve(options_json, *, legacy_hermes_home="", home_base=None):
-    """Run resolve_profiles, return either {'rows': [...]} or {'error': '...'}."""
+def _run_resolve(options_json, *, legacy_hermes_home="", home_base=None, profiles_base=None):
+    """Run resolve_profiles, return either {'rows': [...]} or {'error': '...'}.
+
+    profiles_base: None → inherit profile-init default (`.hermes/profiles`).
+                   string → exported as PROFILES_BASE (empty string disables prefix).
+    """
     with tempfile.TemporaryDirectory() as tmp:
         tmp_path = Path(tmp)
         if home_base is None:
@@ -36,17 +40,23 @@ def _run_resolve(options_json, *, legacy_hermes_home="", home_base=None):
             home_base.mkdir()
         options_path = tmp_path / "options.json"
         options_path.write_text(json.dumps(options_json))
+        export_profiles_base = (
+            f"export PROFILES_BASE={shlex.quote(profiles_base)}"
+            if profiles_base is not None
+            else ""
+        )
         script = textwrap.dedent(f"""
             set -euo pipefail
             export HOME={shlex.quote(str(home_base))}
             export OPTIONS_FILE={shlex.quote(str(options_path))}
             export HERMES_HOME_DIR={shlex.quote(legacy_hermes_home)}
+            {export_profiles_base}
             source {shlex.quote(str(PROFILE_INIT_LIB))}
             resolve_profiles
             for i in "${{!PROFILE_DIRS[@]}}"; do
-                printf 'idx=%d|dir=%s|name=%s|home=%s|src=%s|venv=%s|prefix=%s|marker=%s|api=%d|th=%d|tt=%d|dash=%d\\n' \\
+                printf 'idx=%d|dir=%s|name=%s|home=%s|prefix=%s|marker=%s|api=%d|th=%d|tt=%d|dash=%d\\n' \\
                     "$i" "${{PROFILE_DIRS[$i]}}" "${{PROFILE_NAMES[$i]}}" \\
-                    "${{PROFILE_HOMES[$i]}}" "${{PROFILE_SRC_DIRS[$i]}}" "${{PROFILE_VENV_DIRS[$i]}}" \\
+                    "${{PROFILE_HOMES[$i]}}" \\
                     "${{PROFILE_PATH_PREFIX[$i]}}" "${{PROFILE_MARKER[$i]}}" \\
                     "${{API_PORTS[$i]}}" "${{TTYD_HERMES_PORTS[$i]}}" \\
                     "${{TTYD_TERMINAL_PORTS[$i]}}" "${{DASHBOARD_PORTS[$i]}}"
@@ -124,6 +134,53 @@ class ProfileResolutionTests(unittest.TestCase):
         self.assertEqual(rows[1]["name"], "my_profile_v2")
         self.assertEqual(rows[1]["prefix"], "/profile/my_profile_v2")
 
+    def test_bare_name_resolves_under_default_profiles_base(self):
+        """Bare names without `/` or leading `.` go under PROFILES_BASE (default `.hermes/profiles`)."""
+        res = _run_resolve({"profiles": ["finance-ana"]})
+        home = res["home"]
+        row = res["rows"][0]
+        self.assertEqual(row["dir"], "finance-ana")
+        self.assertEqual(row["name"], "finance_ana")
+        self.assertEqual(row["home"], f"{home}/.hermes/profiles/finance-ana")
+
+    def test_dotted_entry_preserved_as_is(self):
+        """Entries starting with `.` are not re-prefixed (`.hermes` must stay flat)."""
+        res = _run_resolve({"profiles": [".hermes", ".hermes/profiles/manual"]})
+        home = res["home"]
+        rows = res["rows"]
+        self.assertEqual(rows[0]["home"], f"{home}/.hermes")
+        self.assertEqual(rows[1]["home"], f"{home}/.hermes/profiles/manual")
+
+    def test_entry_with_slash_preserved_as_is(self):
+        """Entries containing `/` are taken verbatim (already a relative subpath)."""
+        res = _run_resolve({"profiles": ["primary", "team/finance"]})
+        home = res["home"]
+        rows = res["rows"]
+        self.assertEqual(rows[0]["home"], f"{home}/.hermes/profiles/primary")
+        self.assertEqual(rows[1]["home"], f"{home}/team/finance")
+
+    def test_profiles_base_empty_disables_prefix(self):
+        """Empty PROFILES_BASE preserves the pre-feature layout (`/config/<name>`)."""
+        res = _run_resolve({"profiles": ["amy"]}, profiles_base="")
+        home = res["home"]
+        self.assertEqual(res["rows"][0]["home"], f"{home}/amy")
+
+    def test_profiles_base_custom_value(self):
+        res = _run_resolve(
+            {"profiles": ["alpha", "beta"]},
+            profiles_base="agents",
+        )
+        home = res["home"]
+        rows = res["rows"]
+        self.assertEqual(rows[0]["home"], f"{home}/agents/alpha")
+        self.assertEqual(rows[1]["home"], f"{home}/agents/beta")
+
+    def test_legacy_hermes_home_ignores_profiles_base(self):
+        """Single-profile fallback must keep its pre-feature layout."""
+        res = _run_resolve({}, legacy_hermes_home="amy", profiles_base=".hermes/profiles")
+        home = res["home"]
+        self.assertEqual(res["rows"][0]["home"], f"{home}/amy")
+
     def test_marker_and_home_paths_are_per_profile(self):
         res = _run_resolve(
             {"profiles": [".hermes", "amy"]}
@@ -131,7 +188,8 @@ class ProfileResolutionTests(unittest.TestCase):
         home = res["home"]
         rows = res["rows"]
         self.assertEqual(rows[0]["home"], f"{home}/.hermes")
-        self.assertEqual(rows[0]["src"], f"{home}/.hermes/hermes-agent")
+        # `amy` is bare → goes under default profiles_base.
+        self.assertEqual(rows[1]["home"], f"{home}/.hermes/profiles/amy")
         self.assertEqual(rows[0]["marker"], f"{home}/.hermes_install_hermes")
         self.assertEqual(rows[1]["marker"], f"{home}/.hermes_install_amy")
 
@@ -166,6 +224,7 @@ def _run_env_merge(
             export HOME={shlex.quote(str(home))}
             export OPTIONS_FILE={shlex.quote(str(options_path))}
             export HERMES_HOME_DIR=""
+            export PROFILES_BASE=""
             export ENABLE_API={shlex.quote(enable_api)}
             export ACCESS_PASSWORD={shlex.quote(access_password)}
             source {shlex.quote(str(PROFILE_INIT_LIB))}


### PR DESCRIPTION
Instead of using a separate installation of hermes for each profile, the PR changes the behaviour to use the same hermes install for all profiles. That helps simplify the setup, but doesn't affect the real-world use cases.

`profiles_base` is also added to be explicit about how `profiles` are stored. 

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wolframravenwolf/hermes-ha-addon/pull/13" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->