### PR TITLE
fix(dashboard): execute patch helper directly

### DIFF
--- a/hermes_agent/run.sh
+++ b/hermes_agent/run.sh
@@ -314,7 +314,7 @@ install_profile() {
         local status_file
         status_file="$(mktemp)"
 
-        if ! python /usr/local/bin/hermes-dashboard-patches "$src_dir" "$status_file"; then
+        if ! /usr/local/bin/hermes-dashboard-patches "$src_dir" "$status_file"; then
             echo "[run] [$name] WARNING: dashboard compatibility patch failed - continuing startup"
         fi
         if [ -s "$status_file" ]; then

--- a/tests/test_dashboard_ingress_patches.py
+++ b/tests/test_dashboard_ingress_patches.py
@@ -226,6 +226,8 @@ class DashboardIngressPatchTests(unittest.TestCase):
         run_sh = RUN_SH.read_text()
 
         self.assertIn("hermes-dashboard-patches", run_sh)
+        self.assertIn('/usr/local/bin/hermes-dashboard-patches "$src_dir" "$status_file"', run_sh)
+        self.assertNotIn("python /usr/local/bin/hermes-dashboard-patches", run_sh)
         self.assertNotIn("BASE ||", run_sh)
         self.assertNotIn("HA-ADDON-ROUTER-BASENAME-PATCHED", run_sh)
 


### PR DESCRIPTION
## Summary
- execute the installed dashboard patch helper directly instead of invoking it through `python`
- rely on the helper's `python3` shebang, matching what the add-on image installs
- add a regression assertion so the startup path does not reintroduce a naked `python` dependency

Fixes #14

## Verification
- `python3 -m unittest discover -s tests`
- `bash -n hermes_agent/run.sh`
- `bash -n hermes_agent/profile-init.sh`
- `bash -n hermes_agent/nginx-render.sh`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wolframravenwolf/hermes-ha-addon/pull/15" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->