### PR TITLE
fix(dashboard): keep chat WebSockets alive behind Ingress

### DIFF
--- a/hermes_agent/CHANGELOG.md
+++ b/hermes_agent/CHANGELOG.md
@@ -6,6 +6,20 @@ The format follows the spirit of [Keep a Changelog](https://keepachangelog.com/e
 
 ## [Unreleased]
 
+### Fixed
+
+- Keep Dashboard Chat WebSockets open behind Home Assistant Ingress by enabling `ingress_stream` and rewriting proxied dashboard API `Origin` headers to the dashboard backend host.
+- Fix direct-port Dashboard Chat WebSocket authentication when browsers send Basic auth plus the SPA `?token=` query parameter.
+
+### Verified
+
+- `git diff --check` - OK.
+- `bash -n hermes_agent/nginx-render.sh hermes_agent/run.sh` - OK.
+- `python3 -m py_compile hermes_agent/dashboard-patches.py` - OK.
+- `uv run --with pytest python -m pytest -q tests/test_dashboard_ingress_patches.py` - 21 passed.
+- `uv run --with pytest python -m pytest -q` - 53 passed, 1 skipped.
+- Live Home Assistant local DEV add-on lifecycle smoke - `/dashboard/api/pty` streamed binary TUI frames, `/dashboard/api/ws` emitted `gateway.ready`, and `/dashboard/api/events` stayed open through both HA Ingress and direct HTTPS access.
+
 ## [1.2.0] - 2026-06-15
 
 ### Added

--- a/hermes_agent/config.yaml
+++ b/hermes_agent/config.yaml
@@ -11,6 +11,7 @@ startup: application
 boot: auto
 ingress: true
 ingress_port: 49169
+ingress_stream: true
 panel_icon: mdi:robot
 panel_title: Hermes Agent
 map:

--- a/hermes_agent/nginx-render.sh
+++ b/hermes_agent/nginx-render.sh
@@ -45,10 +45,11 @@ emit_token_maps() {
     for i in "${!PROFILE_DIRS[@]}"; do
         token="${DASHBOARD_TOKENS[$i]}"
         cat <<TOK
-    map "\$http_x_hermes_session_token|\$http_authorization" \$dashboard_token_ok_${i} {
+    map "\$http_x_hermes_session_token|\$http_authorization|\$arg_token" \$dashboard_token_ok_${i} {
         default 0;
         ~^${token}\| 1;
-        ~^\|Bearer\ ${token}\$ 1;
+        ~^\|Bearer\ ${token}\| 1;
+        ~\|${token}\$ 1;
     }
 TOK
     done
@@ -174,6 +175,7 @@ DSTATUS
             proxy_http_version 1.1;
             proxy_set_header Upgrade \$http_upgrade;
             proxy_set_header Connection \$connection_upgrade;
+            proxy_set_header Origin "http://127.0.0.1";
             proxy_set_header Host 127.0.0.1;
             proxy_set_header X-Forwarded-Host \$host;
             proxy_set_header X-Forwarded-Prefix \$dashboard_forwarded_prefix_${i};

--- a/tests/test_dashboard_ingress_patches.py
+++ b/tests/test_dashboard_ingress_patches.py
@@ -14,6 +14,7 @@ RUN_SH = ROOT / "hermes_agent" / "run.sh"
 NGINX_RENDER_LIB = ROOT / "hermes_agent" / "nginx-render.sh"
 NGINX_TEMPLATE = ROOT / "hermes_agent" / "nginx.conf.tpl"
 NGINX_PORTS_TEMPLATE = ROOT / "hermes_agent" / "nginx-ports.conf.tpl"
+ADDON_CONFIG = ROOT / "hermes_agent" / "config.yaml"
 LANDING_TEMPLATE = ROOT / "hermes_agent" / "landing.html.tpl"
 
 
@@ -157,16 +158,27 @@ class DashboardIngressPatchTests(unittest.TestCase):
         self.assertIn("location /dashboard/", rendered)
         self.assertIn("proxy_pass http://hermes_dashboard_0/;", rendered)
 
-    def test_direct_port_dashboard_api_accepts_spa_session_header(self) -> None:
-        """Direct-port nginx guard must match the SPA's current token header."""
+    def test_direct_port_dashboard_api_accepts_spa_session_token_sources(self) -> None:
+        """Direct-port WebSockets must survive Basic auth plus ?token= auth."""
         token_maps = render_nginx_section("token_maps")
 
         self.assertIn("$http_x_hermes_session_token", token_maps)
+        self.assertIn("$http_authorization", token_maps)
+        self.assertIn("$arg_token", token_maps)
         self.assertIn("$dashboard_token_ok_0", token_maps)
         self.assertIn("~^TOK0\\|", token_maps)
-        self.assertIn("~^\\|Bearer\\ TOK0$", token_maps)
+        self.assertIn("~^\\|Bearer\\ TOK0\\|", token_maps)
+        self.assertIn("~\\|TOK0$", token_maps)
         # Per-profile maps are emitted, one per profile.
         self.assertIn("$dashboard_token_ok_1", token_maps)
+
+    def test_addon_enables_ingress_stream_for_websockets(self) -> None:
+        """Home Assistant Ingress must stream WebSocket traffic to the add-on."""
+        addon_config = ADDON_CONFIG.read_text()
+
+        self.assertIn("ingress: true", addon_config)
+        self.assertIn("ingress_port:", addon_config)
+        self.assertIn("ingress_stream: true", addon_config)
 
     def test_nginx_sets_map_hash_bucket_size_before_dashboard_maps(self) -> None:
         """nginx rejects map_hash_bucket_size after any map block has been parsed."""
@@ -200,6 +212,7 @@ class DashboardIngressPatchTests(unittest.TestCase):
                 block = rendered[start:end]
                 self.assertIn("proxy_set_header Upgrade $http_upgrade;", block)
                 self.assertIn("proxy_set_header Connection $connection_upgrade;", block)
+                self.assertIn('proxy_set_header Origin "http://127.0.0.1";', block)
 
     def test_nginx_forwards_dashboard_prefix_to_modern_hermes(self) -> None:
         """Modern Hermes reads X-Forwarded-Prefix to set SPA base paths."""


### PR DESCRIPTION
## Summary

Fixes the remaining Dashboard Chat WebSocket lifecycle failure from #22 after the v1.1.2 upgrade-header fix. The first fix made the WebSocket handshakes reach `101 Switching Protocols`; this patch fixes the follow-up immediate close by addressing the remaining HA Ingress/direct-port lifecycle blockers.

## Root cause

The remaining failure was a stack of three WebSocket proxy/auth issues:

1. Home Assistant Ingress needs `ingress_stream: true` for durable WebSocket/stream forwarding to the add-on.
2. Hermes' dashboard backend is bound to `127.0.0.1`, while browser-originated Ingress requests carry the HA/LAN origin. The backend rejected those WebSockets with an origin mismatch, which HA Ingress masked as `101 Switching Protocols` followed by an immediate `1000 Normal Closure`.
3. Direct-port dashboard WebSockets send the SPA session token via `?token=...`, but browsers may also send the direct-port Basic auth header. The nginx token map only considered the session header/Bearer auth and did not treat the query token as valid in that Basic-auth combination, causing direct-port WebSockets to fail with `401 Unauthorized`.

## Changes

- Add `ingress_stream: true` to the add-on metadata.
- Rewrite proxied `/dashboard/api/` `Origin` to `http://127.0.0.1` so the backend sees the reverse-proxy host it is bound to.
- Extend the direct-port dashboard API token map to include `$arg_token` and accept the SPA query-token form even when `Authorization: Basic ...` is present.
- Add regression coverage for:
  - HA Ingress stream configuration
  - dashboard API Upgrade/Connection headers plus Origin rewrite
  - header/Bearer/query-token map sources for direct-port dashboard API auth
- Document the unreleased fix and live verification evidence in the changelog.

## Verification

Local gates:

- `git diff --check` - OK
- `bash -n hermes_agent/nginx-render.sh hermes_agent/run.sh` - OK
- `python3 -m py_compile hermes_agent/dashboard-patches.py` - OK
- `uv run --with pytest python -m pytest -q tests/test_dashboard_ingress_patches.py` - `21 passed`
- `uv run --with pytest python -m pytest -q` - `53 passed, 1 skipped`

Live Home Assistant DEV add-on lifecycle smoke:

- `/dashboard/api/pty` through HA Ingress streamed binary TUI frames instead of closing.
- `/dashboard/api/ws` through HA Ingress emitted `gateway.ready`.
- `/dashboard/api/events` through HA Ingress stayed open instead of closing immediately.
- The same lifecycle checks passed over direct HTTPS access.

## Notes

- This intentionally leaves #22 open after merge/release until the reporter confirms the fix in their environment.
- No release/version bump is included in this PR; release packaging can promote the changelog entry into the next version section.

Fixes #22 after release.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wolframravenwolf/hermes-ha-addon/pull/24" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->