### PR TITLE
Review only: opt-in Hermes Desktop backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 - **Self-improving skills** -- agent learns and creates new capabilities over time
 - **Multi-platform messaging** -- Telegram, Discord, WhatsApp, and more via the gateway
 - **OpenAI-compatible API** -- connect any chat frontend ([Open WebUI](https://github.com/open-webui/open-webui), [SillyTavern](https://github.com/SillyTavern/SillyTavern), etc.) via `/v1/`
+- **Hermes Desktop backend** -- opt-in remote backend for the official Hermes Desktop app on a dedicated port
 - **Plugin architecture** -- custom tools, commands, and hooks without forking
 - **Self-modifiable source** -- editable install lets the agent read and modify its own code
 - **Web dashboard** -- browser-based management UI for config, API keys, sessions, analytics, logs, cron, and skills
@@ -42,7 +43,8 @@ Add-on-level options are configured in the Home Assistant UI (Settings > Apps > 
 | `enable_dashboard`    | `false`                                            | Enable web dashboard on direct HTTP/HTTPS ports                                 |
 | `enable_terminal`     | `false`                                            | Enable web terminal on direct HTTP/HTTPS ports                                  |
 | `enable_api`          | `false`                                            | Enable the OpenAI-compatible API server on direct HTTP/HTTPS ports              |
-| `access_password`     |                                                    | Password for HTTP/HTTPS access (web terminal). Also used as the server API key  |
+| `enable_desktop_backend` | `false`                                         | Enable the official Hermes Desktop remote backend on container port 9119        |
+| `access_password`     |                                                    | Password for HTTP/HTTPS, API, and Hermes Desktop access (username: `hermes`)    |
 | `env_vars`            | `OPENROUTER_API_KEY` (example)                     | Hermes .env variables — written to each profile's `.env` on each start          |
 | `hermes_home`         | `.hermes`                                          | Single-profile mode: agent profile directory (relative to ~). Ignored if `profiles` is non-empty |
 | `profiles`            | `[]`                                               | Multi-profile mode: list of profile directories run concurrently. First entry is the primary |
@@ -91,7 +93,7 @@ hermes gateway setup  # Configure messaging platforms
 
 The add-on is accessible via the **Home Assistant Sidebar** (landing page with embedded terminal, mode switching, and status display) and, optionally, via direct URLs. Replace `homeassistant.local` with your Home Assistant hostname or IP.
 
-Direct HTTP/HTTPS access requires `enable_dashboard` (**Enable Web Dashboard**), `enable_terminal` (**Enable Web Terminal**), and/or `enable_api` (**Enable API Server**) in the add-on configuration. Set an **Access Password** to secure these ports (username: `hermes`).
+Direct HTTP/HTTPS access requires `enable_dashboard` (**Enable Web Dashboard**), `enable_terminal` (**Enable Web Terminal**), and/or `enable_api` (**Enable API Server**) in the add-on configuration. Set an **Access Password** to secure these ports (username: `hermes`). The separate Hermes Desktop backend requires `enable_desktop_backend`, an access password, and an explicit host-port mapping for container port 9119 under **Network**.
 
 ### Web Terminal & Dashboard
 
@@ -101,6 +103,20 @@ Direct HTTP/HTTPS access requires `enable_dashboard` (**Enable Web Dashboard**),
 | `https://homeassistant.local:8443/dashboard/`  | Web dashboard (config, API keys, sessions, analytics, logs)              |
 | `https://homeassistant.local:8443/terminal/`   | Shell terminal (non-login shell -- plain shell, hermes not auto-started) |
 | `https://homeassistant.local:8443/cert/ca.crt` | CA certificate download (for trusting self-signed HTTPS)                 |
+
+### Hermes Desktop remote backend
+
+The official Hermes Desktop app can use the add-on's primary Hermes installation as a remote backend:
+
+1. Set a strong `access_password`.
+2. Enable `enable_desktop_backend`.
+3. Under the add-on's **Network** settings, map container port `9119` to the host port you want to use (normally `9119`).
+4. In Hermes Desktop, add `http://homeassistant.local:9119` as the remote backend URL, replacing the hostname and host port when necessary.
+5. Log in with username `hermes` and the configured access password.
+
+This opt-in endpoint provides powerful, full agent control. The add-on does not claim process or secret isolation from authenticated agent activity. Enable it only when you accept that risk, and expose it only on a trusted LAN, VPN, or Tailscale path. Do not publish port 9119 directly to the internet.
+
+The Desktop backend derives and pins Hermes' machine root from the primary `HERMES_HOME` before Hermes loads its configuration. Standard Hermes profiles below that machine root remain available through Hermes Desktop; legacy flat profiles outside that root are not promised through this endpoint.
 
 ### OpenAI-compatible API
 
@@ -119,12 +135,13 @@ OpenAI-compatible API access requires `enable_api` (**Enable API Server**) in th
 
 ### Ports
 
-Both ports are configurable in the Home Assistant add-on network settings. Use the HTTPS port (8443) with an access password for secure access. The HTTP port (8080) is intended for TLS-terminating reverse proxies and disabled by default.
+All direct ports are configurable in the Home Assistant add-on network settings. Use the HTTPS port (8443) with an access password for secure browser access. The HTTP port (8080) is intended for TLS-terminating reverse proxies and disabled by default. Port 9119 is the opt-in Hermes Desktop backend and is also unmapped by default.
 
 | Port     | Description                                          |
 | -------- | ---------------------------------------------------- |
 | **8080** | HTTP access (all URLs above, replace 8443 with 8080) |
 | **8443** | HTTPS access (TLS with self-signed cert)             |
+| **9119** | Hermes Desktop remote backend (plain HTTP; trusted LAN/VPN/Tailscale only) |
 
 ### SSH
 
@@ -175,17 +192,19 @@ Authentication layers differ by access path:
   1. **Basic Auth** (username `hermes`, password = `access_password`) gates the landing page, Terminal, and Dashboard HTML.
   2. **Session Token** (ephemeral, rotates on every add-on restart) gates dashboard API calls. The token is injected into the dashboard HTML on load — only clients who successfully loaded the page via Basic Auth ever see it. Requests to `/dashboard/api/*` without a matching Bearer token return 401. Only `/dashboard/api/status` is public (it mirrors Hermes' own whitelist and powers the landing page health indicator). If the dashboard process is restarted without restarting the add-on, the nginx-side token cache goes stale — restart the add-on to re-sync.
 - **OpenAI-compatible API** (`/v1/*`): Bearer token authentication. The `access_password` doubles as the API key, passed as `Authorization: Bearer <api-key>`.
+- **Hermes Desktop backend** (`:9119` when enabled and mapped): Hermes Basic-auth login using username `hermes` and `access_password`. This endpoint exposes the full Desktop backend contract, including chat, WebSockets, PTY, events, profiles, and agent control. It is disabled and unmapped by default. Enabling it is an explicit risk decision; keep it on a trusted LAN/VPN/Tailscale path and do not expose it directly to the internet.
 
 If you expose direct ports to the internet, place a network-perimeter gate (firewall, VPN, reverse proxy with stronger auth) in front — Basic Auth alone is not brute-force resistant.
 
 ## Architecture
 
-Four services in a Debian Bookworm container:
+Five service families in a Debian Bookworm container:
 
 1. **Hermes Gateway** (`hermes gateway run`) -- persistent AI agent daemon with OpenAI-compatible API server and messaging platform connectors. Logs visible in the Home Assistant add-on log and in `~/.hermes/logs/gateway.log`.
 2. **Hermes Dashboard** (`hermes dashboard`) -- browser-based management UI (FastAPI + React) for config, API keys, sessions, analytics, logs, cron jobs, and skills.
 3. **ttyd** (×2 per profile) -- web terminals backed by persistent tmux sessions (`hermes-<name>` + `terminal-<name>`)
 4. **nginx** -- HTTP, HTTPS, and Home Assistant ingress proxy routing to dashboard + terminal + API. Multi-profile setups serve `/profile/<name>/...` for non-primary profiles.
+5. **Hermes Desktop backend** (`hermes serve`, optional) -- official root-level HTTP/WebSocket backend on container port 9119, using the primary Hermes machine root and Basic-auth login.
 
 ### Shell Environment
 

--- a/hermes_agent/CHANGELOG.md
+++ b/hermes_agent/CHANGELOG.md
@@ -6,6 +6,8 @@ The format follows the spirit of [Keep a Changelog](https://keepachangelog.com/e
 
 ## [Unreleased]
 
+## [1.3.0] - 2026-07-19
+
 ### Added
 
 - Add an opt-in Hermes Desktop remote backend on container port 9119 using the official `hermes serve` contract and the existing access password.
@@ -15,6 +17,15 @@ The format follows the spirit of [Keep a Changelog](https://keepachangelog.com/e
 
 - Require `access_password` whenever the Desktop backend is enabled.
 - Warn that authenticated Desktop access provides full agent control, carries the accepted opt-in risk, and belongs only on a trusted LAN/VPN/Tailscale path rather than the public internet.
+
+### Verified
+
+- `PYTHONDONTWRITEBYTECODE=1 /usr/bin/python3 -B -m unittest discover -s tests -v` - 66 tests OK, 1 skipped.
+- Shell syntax, Python AST, YAML parsing, public-repository hygiene, and `git diff --check` passed.
+- An isolated Home Assistant test repository built and installed the add-on without changing the stopped production installation.
+- The live remote backend enforced authentication, exposed the `default` and `worker` profiles, minted single-use WebSocket tickets, and rejected ticket reuse.
+- The codesign-verified Hermes Desktop app connected through its real cookie-authenticated remote path and reached the expected provider onboarding for the credential-free test profile.
+- Independent code reviews completed with no blocking findings.
 
 ## [1.2.1] - 2026-06-18
 

--- a/hermes_agent/CHANGELOG.md
+++ b/hermes_agent/CHANGELOG.md
@@ -6,6 +6,16 @@ The format follows the spirit of [Keep a Changelog](https://keepachangelog.com/e
 
 ## [Unreleased]
 
+### Added
+
+- Add an opt-in Hermes Desktop remote backend on container port 9119 using the official `hermes serve` contract and the existing access password.
+- Keep the Desktop port unmapped and the feature disabled by default; Home Assistant's Network settings choose the external host port.
+
+### Security
+
+- Require `access_password` whenever the Desktop backend is enabled.
+- Warn that authenticated Desktop access provides full agent control, carries the accepted opt-in risk, and belongs only on a trusted LAN/VPN/Tailscale path rather than the public internet.
+
 ## [1.2.1] - 2026-06-18
 
 ### Fixed

--- a/hermes_agent/Dockerfile
+++ b/hermes_agent/Dockerfile
@@ -79,13 +79,15 @@ RUN su - linuxbrew -c \
 COPY run.sh /
 COPY nginx-render.sh /usr/local/lib/hermes-nginx-render.sh
 COPY profile-init.sh /usr/local/lib/hermes-profile-init.sh
+COPY desktop-backend.sh /usr/local/lib/hermes-desktop-backend.sh
+COPY desktop-backend-launcher.py /usr/local/bin/hermes-desktop-backend
 COPY nginx.conf.tpl /etc/nginx/nginx.conf.tpl
 COPY nginx-ports.conf.tpl /etc/nginx/nginx-ports.conf.tpl
 COPY landing.html.tpl /var/www/landing.html.tpl
 COPY loading.html /var/www/loading.html
 COPY brew-wrapper.sh /usr/local/bin/brew-wrapper
 COPY dashboard-patches.py /usr/local/bin/hermes-dashboard-patches
-RUN chmod +x /run.sh /usr/local/bin/brew-wrapper /usr/local/bin/hermes-dashboard-patches
+RUN chmod +x /run.sh /usr/local/bin/brew-wrapper /usr/local/bin/hermes-dashboard-patches /usr/local/bin/hermes-desktop-backend
 
 # ── nginx dirs ───────────────────────────────────────────────────────
 RUN mkdir -p /var/www /var/log/nginx /run/nginx

--- a/hermes_agent/config.yaml
+++ b/hermes_agent/config.yaml
@@ -21,9 +21,11 @@ map:
 ports:
   8080/tcp: null
   8443/tcp: 8443
+  9119/tcp: null
 ports_description:
   8080/tcp: "HTTP: /hermes/ (agent) · /dashboard/ (web UI) · /terminal/ (shell) · /v1/ (OpenAI API)"
   8443/tcp: "HTTPS: /hermes/ (agent) · /dashboard/ (web UI) · /terminal/ (shell) · /v1/ (OpenAI API) — TLS (self-signed cert)"
+  9119/tcp: "Hermes Desktop remote backend — opt-in; trusted LAN/VPN/Tailscale only"
 options:
   git_url: "https://github.com/NousResearch/hermes-agent.git"
   git_ref: ""
@@ -38,6 +40,7 @@ options:
   enable_dashboard: false
   enable_terminal: false
   enable_api: false
+  enable_desktop_backend: false
   access_password: ""
   env_vars:
     - name: "OPENROUTER_API_KEY"
@@ -60,6 +63,7 @@ schema:
   enable_dashboard: "bool"
   enable_terminal: "bool"
   enable_api: "bool"
+  enable_desktop_backend: "bool"
   access_password: "password?"
   env_vars:
     - name: "match(^[A-Z_][A-Z0-9_]{0,254}$)"

--- a/hermes_agent/config.yaml
+++ b/hermes_agent/config.yaml
@@ -1,5 +1,5 @@
 name: Hermes Agent
-version: "1.2.1"
+version: "1.3.0"
 slug: hermes_agent
 description: "The self-improving AI agent built by Nous Research. Home Assistant add-on by Wolfram Ravenwolf."
 url: "https://github.com/WolframRavenwolf/hermes-ha-addon"

--- a/hermes_agent/desktop-backend-launcher.py
+++ b/hermes_agent/desktop-backend-launcher.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Start the official Hermes Desktop backend with add-on-owned Basic auth."""
+
+from __future__ import annotations
+
+from importlib import import_module
+import os
+import sys
+
+
+_BASIC_AUTH_ENV_KEYS = (
+    "HERMES_DASHBOARD_BASIC_AUTH_USERNAME",
+    "HERMES_DASHBOARD_BASIC_AUTH_PASSWORD",
+    "HERMES_DASHBOARD_BASIC_AUTH_PASSWORD_HASH",
+    "HERMES_DASHBOARD_BASIC_AUTH_SECRET",
+    "HERMES_DASHBOARD_BASIC_AUTH_TTL_SECONDS",
+)
+
+
+def _read_password() -> str:
+    password = sys.stdin.read()
+    # run.sh supplies the option through a Bash here-string, which appends one
+    # newline. Remove only that transport newline so spaces remain untouched.
+    if password.endswith("\n"):
+        password = password[:-1]
+    if not password:
+        raise SystemExit(
+            "[desktop-backend] FATAL: no access password received on stdin"
+        )
+    return password
+
+
+def main() -> int:
+    password = _read_password()
+    serve_args = sys.argv[1:]
+    # Pin the official machine-level backend before Hermes' import-time profile
+    # selection. This avoids a later named-profile re-exec that would bypass
+    # this launcher and reload colliding machine-root environment layers.
+    sys.argv = ["hermes", "-p", "default", "serve", *serve_args]
+
+    # Import first: Hermes resolves the machine HERMES_HOME and loads profile,
+    # project, external-secret and managed environment layers at module import
+    # time. The explicit default profile is stripped from sys.argv during this
+    # import, leaving the normal `hermes serve ...` dispatch contract.
+    from hermes_cli import main as hermes_main
+
+    hash_password = import_module(
+        "plugins.dashboard_auth.basic"
+    ).hash_password
+
+    try:
+        password_hash = hash_password(password)
+    except Exception as exc:
+        raise SystemExit(
+            "[desktop-backend] FATAL: could not hash the access password "
+            f"({type(exc).__name__})"
+        ) from exc
+
+    # The add-on option is authoritative for this opt-in listener. Remove any
+    # colliding Hermes-loaded auth settings, then configure the normal Basic
+    # auth plugin with an exact hash before hermes_cli.main() performs plugin
+    # discovery. Plaintext never enters the post-import process environment.
+    for key in _BASIC_AUTH_ENV_KEYS:
+        os.environ.pop(key, None)
+    os.environ["HERMES_DASHBOARD_BASIC_AUTH_USERNAME"] = "hermes"
+    os.environ["HERMES_DASHBOARD_BASIC_AUTH_PASSWORD_HASH"] = password_hash
+    del password, password_hash
+
+    result = hermes_main.main()
+    return result if isinstance(result, int) else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/hermes_agent/desktop-backend.sh
+++ b/hermes_agent/desktop-backend.sh
@@ -1,0 +1,118 @@
+#!/bin/bash
+# shellcheck shell=bash
+# Optional Hermes Desktop remote-backend lifecycle helpers.
+
+DESKTOP_BACKEND_PORT="${DESKTOP_BACKEND_PORT:-9119}"
+DESKTOP_BACKEND_LAUNCHER="${DESKTOP_BACKEND_LAUNCHER:-/usr/local/bin/hermes-desktop-backend}"
+DESKTOP_BACKEND_STOP_TIMEOUT="${DESKTOP_BACKEND_STOP_TIMEOUT:-10}"
+DESKTOP_BACKEND_PID="${DESKTOP_BACKEND_PID:-}"
+
+
+desktop_backend_validate_options() {
+    if [ "${ENABLE_DESKTOP_BACKEND:-false}" != "true" ]; then
+        return 0
+    fi
+    local password="${ACCESS_PASSWORD:-}"
+    if [ -z "$password" ] || [ -z "${password//[[:space:]]/}" ]; then
+        echo "[desktop-backend] FATAL: enable_desktop_backend requires access_password" >&2
+        return 1
+    fi
+}
+
+
+desktop_backend_validate_runtime() {
+    if [ "${ENABLE_DESKTOP_BACKEND:-false}" != "true" ]; then
+        return 0
+    fi
+    if [ ! -x "${VENV_DIR:-}/bin/python" ]; then
+        echo "[desktop-backend] FATAL: Hermes venv Python is unavailable" >&2
+        return 1
+    fi
+    if [ ! -x "${VENV_DIR:-}/bin/hermes" ]; then
+        echo "[desktop-backend] FATAL: Hermes CLI is unavailable" >&2
+        return 1
+    fi
+    if [ ! -f "$DESKTOP_BACKEND_LAUNCHER" ]; then
+        echo "[desktop-backend] FATAL: launcher not found: $DESKTOP_BACKEND_LAUNCHER" >&2
+        return 1
+    fi
+    local serve_help
+    if ! serve_help=$("$VENV_DIR/bin/hermes" serve --help 2>&1); then
+        echo "[desktop-backend] FATAL: installed Hermes does not support 'hermes serve'" >&2
+        return 1
+    fi
+    case "$serve_help" in
+        *--skip-build*) ;;
+        *)
+            echo "[desktop-backend] FATAL: installed Hermes 'serve' does not support required --skip-build" >&2
+            return 1
+            ;;
+    esac
+}
+
+
+desktop_backend_start() {
+    if [ "${ENABLE_DESKTOP_BACKEND:-false}" != "true" ]; then
+        DESKTOP_BACKEND_PID=""
+        return 0
+    fi
+
+    echo "[desktop-backend] WARNING: enabled on container port ${DESKTOP_BACKEND_PORT}; expose only on a trusted LAN/VPN/Tailscale path."
+    echo "[desktop-backend] WARNING: authenticated users receive powerful, full agent control and accept that risk."
+    echo "[desktop-backend] Starting official Hermes Desktop backend..."
+    (
+        cd "$PRIMARY_HOME"
+        export HERMES_HOME="$PRIMARY_HOME"
+        export PATH="$VENV_DIR/bin:$BASE_PATH"
+        exec "$VENV_DIR/bin/python" "$DESKTOP_BACKEND_LAUNCHER" \
+            --host 0.0.0.0 \
+            --port "$DESKTOP_BACKEND_PORT" \
+            --skip-build <<<"$ACCESS_PASSWORD"
+    ) &
+    DESKTOP_BACKEND_PID=$!
+    echo "[desktop-backend] PID: $DESKTOP_BACKEND_PID"
+}
+
+
+desktop_backend_stop() {
+    local pid="${DESKTOP_BACKEND_PID:-}"
+    if [ -z "$pid" ]; then
+        return 0
+    fi
+    if kill -0 "$pid" 2>/dev/null; then
+        kill -TERM "$pid" 2>/dev/null || true
+        local waited=0
+        while kill -0 "$pid" 2>/dev/null && [ "$waited" -lt "$DESKTOP_BACKEND_STOP_TIMEOUT" ]; do
+            sleep 1
+            waited=$((waited + 1))
+        done
+        if kill -0 "$pid" 2>/dev/null; then
+            echo "[desktop-backend] Process did not stop gracefully; force killing..."
+            kill -KILL "$pid" 2>/dev/null || true
+        fi
+        wait "$pid" 2>/dev/null || true
+    fi
+    DESKTOP_BACKEND_PID=""
+    echo "[desktop-backend] Stopped"
+}
+
+
+desktop_backend_supervise() {
+    if [ "${ENABLE_DESKTOP_BACKEND:-false}" != "true" ]; then
+        return 0
+    fi
+    local pid="${DESKTOP_BACKEND_PID:-}"
+    if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+        return 0
+    fi
+
+    local exit_code=0
+    if [ -n "$pid" ]; then
+        set +e
+        wait "$pid" 2>/dev/null
+        exit_code=$?
+        set -e
+    fi
+    echo "[desktop-backend] Exited (code: $exit_code); restarting..."
+    desktop_backend_start
+}

--- a/hermes_agent/run.sh
+++ b/hermes_agent/run.sh
@@ -31,6 +31,7 @@ PROFILES_BASE=$(jq -r 'if has("profiles_base") then (.profiles_base // "") else 
 ENABLE_DASHBOARD=$(opt_bool enable_dashboard)
 ENABLE_TERMINAL=$(opt_bool enable_terminal)
 ENABLE_API=$(opt_bool enable_api)
+ENABLE_DESKTOP_BACKEND=$(opt_bool enable_desktop_backend)
 ACCESS_PASSWORD=$(opt access_password)
 
 # ── Section 2: System setup ─────────────────────────────────────────
@@ -91,6 +92,26 @@ CERTS_DIR="$HOME/.certs"
 INGRESS_PORT=49169
 HTTP_PORT=8080
 HTTPS_PORT=8443
+DESKTOP_BACKEND_PORT=9119
+
+# Desktop backend lifecycle helpers. The feature is opt-in and validation runs
+# before nginx or any Hermes service starts.
+DESKTOP_BACKEND_LIB=""
+for _candidate in \
+    "/usr/local/lib/hermes-desktop-backend.sh" \
+    "$(dirname "${BASH_SOURCE[0]}")/desktop-backend.sh"; do
+    if [ -f "$_candidate" ]; then
+        DESKTOP_BACKEND_LIB="$_candidate"
+        break
+    fi
+done
+if [ -z "$DESKTOP_BACKEND_LIB" ]; then
+    echo "[run] FATAL: desktop-backend.sh not found"
+    exit 1
+fi
+# shellcheck source=desktop-backend.sh
+source "$DESKTOP_BACKEND_LIB"
+desktop_backend_validate_options || exit 1
 
 # Start nginx early with loading page (replaced with full config after setup)
 cat > /etc/nginx/nginx.conf << LOADCONF
@@ -353,6 +374,7 @@ source "$VENV_DIR/bin/activate"
 HERMES_VERSION="$("$VENV_DIR/bin/hermes" --version 2>/dev/null | head -1 || echo "unknown")"
 export HERMES_VERSION
 echo "[run] Hermes version: $HERMES_VERSION"
+desktop_backend_validate_runtime || exit 1
 
 # ── Section 6: Initial config scaffolding (per profile) ──────────────
 scaffold_profile_files() {
@@ -600,6 +622,7 @@ GATEWAY_PIDS=()
 TTYD_HERMES_PIDS=()
 TTYD_TERMINAL_PIDS=()
 DASHBOARD_PIDS=()
+DESKTOP_BACKEND_PID=""
 
 start_gateway_for_profile() {
     local i="$1"
@@ -738,6 +761,41 @@ reload_nginx() {
     echo "[run] nginx reloaded"
 }
 
+# ── Section 11: Signal handling ──────────────────────────────────────
+shutdown() {
+    echo ""
+    echo "[run] Shutting down..."
+    nginx -s quit 2>/dev/null || true
+    echo "[run] nginx stopped"
+    desktop_backend_stop
+    for i in "${!PROFILE_DIRS[@]}"; do
+        for pid in "${TTYD_TERMINAL_PIDS[$i]:-}" "${TTYD_HERMES_PIDS[$i]:-}" "${DASHBOARD_PIDS[$i]:-}"; do
+            if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+                kill "$pid" 2>/dev/null || true
+            fi
+        done
+    done
+    echo "[run] ttyd + dashboards stopped"
+    for i in "${!PROFILE_DIRS[@]}"; do
+        local pid="${GATEWAY_PIDS[$i]:-}"
+        if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+            kill -TERM "$pid" 2>/dev/null || true
+            local waited=0
+            while kill -0 "$pid" 2>/dev/null && [ $waited -lt 10 ]; do
+                sleep 1
+                waited=$((waited + 1))
+            done
+            if kill -0 "$pid" 2>/dev/null; then
+                echo "[run] [${PROFILE_NAMES[$i]}] Gateway didn't stop gracefully, force killing..."
+                kill -9 "$pid" 2>/dev/null || true
+            fi
+            echo "[run] [${PROFILE_NAMES[$i]}] Gateway stopped"
+        fi
+    done
+    echo "[run] Shutdown complete"
+    exit 0
+}
+
 # Register signal handler BEFORE starting services
 trap shutdown SIGTERM SIGINT
 
@@ -748,6 +806,8 @@ for i in "${!PROFILE_DIRS[@]}"; do
     start_ttyd_for_profile "$i"
     start_dashboard_for_profile "$i"
 done
+
+desktop_backend_start
 
 for i in "${!PROFILE_DIRS[@]}"; do
     inject_dashboard_token_for_profile "$i"
@@ -780,44 +840,12 @@ for i in "${!PROFILE_DIRS[@]}"; do
     echo "   Terminal:  ${BASE_URL}${prefix}/terminal/"
     echo "   API:       ${BASE_URL}${prefix}/v1/"
 done
+[ "$ENABLE_DESKTOP_BACKEND" = "true" ] && echo " Desktop:    container port ${DESKTOP_BACKEND_PORT} (use the Home Assistant Network host port)"
 echo "─────────────────────────────────────────────"
-
-# ── Section 11: Signal handling ──────────────────────────────────────
-shutdown() {
-    echo ""
-    echo "[run] Shutting down..."
-    nginx -s quit 2>/dev/null || true
-    echo "[run] nginx stopped"
-    for i in "${!PROFILE_DIRS[@]}"; do
-        for pid in "${TTYD_TERMINAL_PIDS[$i]:-}" "${TTYD_HERMES_PIDS[$i]:-}" "${DASHBOARD_PIDS[$i]:-}"; do
-            if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
-                kill "$pid" 2>/dev/null || true
-            fi
-        done
-    done
-    echo "[run] ttyd + dashboards stopped"
-    for i in "${!PROFILE_DIRS[@]}"; do
-        local pid="${GATEWAY_PIDS[$i]:-}"
-        if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
-            kill -TERM "$pid" 2>/dev/null || true
-            local waited=0
-            while kill -0 "$pid" 2>/dev/null && [ $waited -lt 10 ]; do
-                sleep 1
-                waited=$((waited + 1))
-            done
-            if kill -0 "$pid" 2>/dev/null; then
-                echo "[run] [${PROFILE_NAMES[$i]}] Gateway didn't stop gracefully, force killing..."
-                kill -9 "$pid" 2>/dev/null || true
-            fi
-            echo "[run] [${PROFILE_NAMES[$i]}] Gateway stopped"
-        fi
-    done
-    echo "[run] Shutdown complete"
-    exit 0
-}
 
 # ── Section 12: Supervisor loop ──────────────────────────────────────
 while true; do
+    desktop_backend_supervise
     for i in "${!PROFILE_DIRS[@]}"; do
         pid="${GATEWAY_PIDS[$i]:-}"
         if [ -z "$pid" ] || ! kill -0 "$pid" 2>/dev/null; then

--- a/hermes_agent/translations/en.yaml
+++ b/hermes_agent/translations/en.yaml
@@ -37,11 +37,17 @@ configuration:
     description: >-
       ⚠️ Enable the OpenAI-compatible API server on direct HTTP/HTTPS ports (configured under Network below).
       The access password doubles as the server API key.
+  enable_desktop_backend:
+    name: Enable Hermes Desktop Backend
+    description: >-
+      ⚠️ Opt in to the powerful Hermes Desktop remote backend on container port 9119.
+      Requires an access password. Map the port under Network and expose it only on a trusted LAN/VPN/Tailscale path.
+      Authenticated Desktop users receive full agent control and accept that risk.
   access_password:
     name: Access Password
     description: >-
       ⚠️ Password for direct HTTP/HTTPS access. Username: hermes.
-      Also used as the server API key.
+      Also used as the server API key and Hermes Desktop password.
   env_vars:
     name: Hermes .env Variables
     description: >-

--- a/tests/test_desktop_backend.py
+++ b/tests/test_desktop_backend.py
@@ -1,0 +1,481 @@
+"""Behavior tests for the optional Hermes Desktop remote backend."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import textwrap
+import time
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+ADDON = ROOT / "hermes_agent"
+CONFIG = ADDON / "config.yaml"
+RUN_SH = ADDON / "run.sh"
+DESKTOP_LIB = ADDON / "desktop-backend.sh"
+DESKTOP_LAUNCHER = ADDON / "desktop-backend-launcher.py"
+DOCKERFILE = ADDON / "Dockerfile"
+TRANSLATIONS = ADDON / "translations" / "en.yaml"
+README = ROOT / "README.md"
+CHANGELOG = ADDON / "CHANGELOG.md"
+BASH = "/bin/bash" if sys.platform == "darwin" else "bash"
+
+
+def run_bash(script: str, *, env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
+    merged = os.environ.copy()
+    if env:
+        merged.update(env)
+    return subprocess.run(
+        [BASH, "-c", script],
+        check=False,
+        text=True,
+        capture_output=True,
+        env=merged,
+    )
+
+
+class DesktopBackendConfigurationTests(unittest.TestCase):
+    def test_feature_is_opt_in_and_host_port_is_unmapped_by_default(self) -> None:
+        config = CONFIG.read_text()
+
+        self.assertIn("enable_desktop_backend: false", config)
+        self.assertIn("enable_desktop_backend: \"bool\"", config)
+        self.assertIn("9119/tcp: null", config)
+        self.assertIn("9119/tcp:", config)
+        self.assertNotIn("desktop_backend_port:", config)
+
+    def test_container_ships_the_runtime_library_and_launcher(self) -> None:
+        dockerfile = DOCKERFILE.read_text()
+
+        self.assertIn(
+            "COPY desktop-backend.sh /usr/local/lib/hermes-desktop-backend.sh",
+            dockerfile,
+        )
+        self.assertIn(
+            "COPY desktop-backend-launcher.py /usr/local/bin/hermes-desktop-backend",
+            dockerfile,
+        )
+
+    def test_user_facing_text_states_opt_in_risk_and_trusted_network_boundary(self) -> None:
+        translations = TRANSLATIONS.read_text()
+        readme = README.read_text()
+        changelog = CHANGELOG.read_text()
+
+        for text in (translations, readme):
+            self.assertIn("enable_desktop_backend", text)
+            self.assertIn("9119", text)
+            self.assertRegex(text, r"(?i)LAN|VPN|Tailscale")
+            self.assertRegex(text, r"(?i)risk|powerful|full agent control")
+        self.assertIn("Hermes Desktop", changelog)
+        self.assertIn("opt-in", changelog)
+
+
+class DesktopBackendLauncherTests(unittest.TestCase):
+    def test_machine_root_pin_and_exact_password_hash_win_after_env_loading(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            package = root / "hermes_cli"
+            package.mkdir()
+            (package / "__init__.py").write_text("")
+            (package / "main.py").write_text(
+                textwrap.dedent(
+                    """
+                    import json
+                    import os
+                    import sys
+                    from pathlib import Path
+
+                    argv_at_import = list(sys.argv)
+                    if sys.argv[1:3] == ["-p", "default"]:
+                        sys.argv = [sys.argv[0], *sys.argv[3:]]
+
+                    # Simulate Hermes loading colliding machine-root env layers.
+                    os.environ["HERMES_DASHBOARD_BASIC_AUTH_USERNAME"] = "wrong-user"
+                    os.environ["HERMES_DASHBOARD_BASIC_AUTH_PASSWORD"] = "wrong-password"
+                    os.environ["HERMES_DASHBOARD_BASIC_AUTH_PASSWORD_HASH"] = "wrong-hash"
+                    os.environ["HERMES_DASHBOARD_BASIC_AUTH_SECRET"] = "wrong-secret"
+
+                    def main():
+                        payload = {
+                            "argv_at_import": argv_at_import,
+                            "argv": sys.argv,
+                            "username": os.environ.get("HERMES_DASHBOARD_BASIC_AUTH_USERNAME"),
+                            "password_present": "HERMES_DASHBOARD_BASIC_AUTH_PASSWORD" in os.environ,
+                            "password_hash": os.environ.get("HERMES_DASHBOARD_BASIC_AUTH_PASSWORD_HASH"),
+                            "secret_present": "HERMES_DASHBOARD_BASIC_AUTH_SECRET" in os.environ,
+                        }
+                        Path(os.environ["RESULT_FILE"]).write_text(json.dumps(payload))
+                        return 0
+                    """
+                )
+            )
+            basic = root / "plugins" / "dashboard_auth" / "basic"
+            basic.mkdir(parents=True)
+            (root / "plugins" / "__init__.py").write_text("")
+            (root / "plugins" / "dashboard_auth" / "__init__.py").write_text("")
+            (basic / "__init__.py").write_text(
+                "def hash_password(password):\n"
+                "    return 'fake$' + password.encode('utf-8').hex()\n"
+            )
+            result_file = root / "result.json"
+            env = os.environ.copy()
+            env.update(
+                {
+                    "PYTHONPATH": str(root),
+                    "RESULT_FILE": str(result_file),
+                }
+            )
+            password = " correct horse battery staple "
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(DESKTOP_LAUNCHER),
+                    "--host",
+                    "0.0.0.0",
+                    "--port",
+                    "9119",
+                    "--skip-build",
+                ],
+                input=password + "\n",
+                text=True,
+                capture_output=True,
+                check=False,
+                env=env,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            payload = json.loads(result_file.read_text())
+            self.assertEqual(
+                payload["argv_at_import"],
+                [
+                    "hermes",
+                    "-p",
+                    "default",
+                    "serve",
+                    "--host",
+                    "0.0.0.0",
+                    "--port",
+                    "9119",
+                    "--skip-build",
+                ],
+            )
+            self.assertEqual(
+                payload["argv"],
+                [
+                    "hermes",
+                    "serve",
+                    "--host",
+                    "0.0.0.0",
+                    "--port",
+                    "9119",
+                    "--skip-build",
+                ],
+            )
+            self.assertEqual(payload["username"], "hermes")
+            self.assertFalse(payload["password_present"])
+            self.assertEqual(payload["password_hash"], "fake$" + password.encode().hex())
+            self.assertFalse(payload["secret_present"])
+            self.assertNotIn(password, " ".join(payload["argv_at_import"]))
+
+
+class DesktopBackendShellTests(unittest.TestCase):
+    def test_disabled_feature_needs_no_password_and_starts_nothing(self) -> None:
+        script = textwrap.dedent(
+            f"""
+            set -euo pipefail
+            source {DESKTOP_LIB!s}
+            ENABLE_DESKTOP_BACKEND=false
+            ACCESS_PASSWORD=""
+            DESKTOP_BACKEND_PID=""
+            desktop_backend_validate_options
+            desktop_backend_start
+            test -z "$DESKTOP_BACKEND_PID"
+            """
+        )
+
+        result = run_bash(script)
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_enabled_feature_requires_access_password(self) -> None:
+        script = textwrap.dedent(
+            f"""
+            set -euo pipefail
+            source {DESKTOP_LIB!s}
+            ENABLE_DESKTOP_BACKEND=true
+            ACCESS_PASSWORD=""
+            desktop_backend_validate_options
+            """
+        )
+
+        result = run_bash(script)
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("access_password", result.stderr)
+
+    def test_enabled_feature_rejects_whitespace_only_password(self) -> None:
+        script = textwrap.dedent(
+            f"""
+            set -euo pipefail
+            source {DESKTOP_LIB!s}
+            ENABLE_DESKTOP_BACKEND=true
+            ACCESS_PASSWORD=$' \\t '
+            desktop_backend_validate_options
+            """
+        )
+
+        result = run_bash(script)
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("access_password", result.stderr)
+
+    def test_enabled_runtime_rejects_serve_without_skip_build(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            venv_bin = root / "venv" / "bin"
+            venv_bin.mkdir(parents=True)
+            fake_python = venv_bin / "python"
+            fake_python.write_text("#!/bin/bash\nexit 0\n")
+            fake_python.chmod(0o755)
+            fake_hermes = venv_bin / "hermes"
+            fake_hermes.write_text(
+                "#!/bin/bash\nprintf '%s\\n' 'usage: hermes serve --host HOST --port PORT'\n"
+            )
+            fake_hermes.chmod(0o755)
+            script = textwrap.dedent(
+                f"""
+                set -euo pipefail
+                source {DESKTOP_LIB!s}
+                ENABLE_DESKTOP_BACKEND=true
+                ACCESS_PASSWORD=password
+                VENV_DIR={root / 'venv'!s}
+                DESKTOP_BACKEND_LAUNCHER={DESKTOP_LAUNCHER!s}
+                desktop_backend_validate_runtime
+                """
+            )
+
+            result = run_bash(script)
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("--skip-build", result.stderr)
+
+    def test_start_uses_official_serve_contract_and_password_stdin(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            venv_bin = root / "venv" / "bin"
+            venv_bin.mkdir(parents=True)
+            fake_python = venv_bin / "python"
+            fake_python.write_text(
+                textwrap.dedent(
+                    """#!/bin/bash
+                    set -euo pipefail
+                    printf '%s\n' "$@" > "$CAPTURE_ARGS"
+                    cat > "$CAPTURE_STDIN"
+                    trap 'exit 0' TERM INT
+                    while :; do sleep 1; done
+                    """
+                )
+            )
+            fake_python.chmod(0o755)
+            fake_hermes = venv_bin / "hermes"
+            fake_hermes.write_text("#!/bin/bash\nprintf '%s\\n' '--skip-build'\n")
+            fake_hermes.chmod(0o755)
+            primary_home = root / "profile"
+            primary_home.mkdir()
+            capture_args = root / "args"
+            capture_stdin = root / "stdin"
+            env = {
+                "CAPTURE_ARGS": str(capture_args),
+                "CAPTURE_STDIN": str(capture_stdin),
+            }
+            script = textwrap.dedent(
+                f"""
+                set -euo pipefail
+                source {DESKTOP_LIB!s}
+                ENABLE_DESKTOP_BACKEND=true
+                ACCESS_PASSWORD='a password with spaces'
+                PRIMARY_HOME={primary_home!s}
+                VENV_DIR={root / 'venv'!s}
+                BASE_PATH=/usr/bin:/bin
+                DESKTOP_BACKEND_PORT=9119
+                DESKTOP_BACKEND_LAUNCHER={DESKTOP_LAUNCHER!s}
+                DESKTOP_BACKEND_PID=""
+                trap desktop_backend_stop EXIT
+                desktop_backend_validate_options
+                desktop_backend_validate_runtime
+                desktop_backend_start
+                sleep 0.2
+                test -n "$DESKTOP_BACKEND_PID"
+                kill -0 "$DESKTOP_BACKEND_PID"
+                desktop_backend_stop
+                """
+            )
+
+            result = run_bash(script, env=env)
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            args = capture_args.read_text().splitlines()
+            self.assertEqual(
+                args,
+                [
+                    str(DESKTOP_LAUNCHER),
+                    "--host",
+                    "0.0.0.0",
+                    "--port",
+                    "9119",
+                    "--skip-build",
+                ],
+            )
+            self.assertEqual(capture_stdin.read_text(), "a password with spaces\n")
+            self.assertNotIn("a password with spaces", " ".join(args))
+            self.assertIn("trusted LAN/VPN/Tailscale", result.stdout)
+
+    def test_supervisor_restarts_a_crashed_backend_and_stop_terminates_replacement(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            venv_bin = root / "venv" / "bin"
+            venv_bin.mkdir(parents=True)
+            fake_python = venv_bin / "python"
+            fake_python.write_text(
+                textwrap.dedent(
+                    """#!/bin/bash
+                    set -euo pipefail
+                    count=0
+                    [ ! -f "$COUNT_FILE" ] || count=$(cat "$COUNT_FILE")
+                    count=$((count + 1))
+                    printf '%s' "$count" > "$COUNT_FILE"
+                    cat >/dev/null
+                    if [ "$count" -eq 1 ]; then exit 7; fi
+                    trap 'exit 0' TERM INT
+                    while :; do sleep 1; done
+                    """
+                )
+            )
+            fake_python.chmod(0o755)
+            fake_hermes = venv_bin / "hermes"
+            fake_hermes.write_text("#!/bin/bash\nprintf '%s\\n' '--skip-build'\n")
+            fake_hermes.chmod(0o755)
+            primary_home = root / "profile"
+            primary_home.mkdir()
+            count_file = root / "count"
+            env = {"COUNT_FILE": str(count_file)}
+            script = textwrap.dedent(
+                f"""
+                set -euo pipefail
+                source {DESKTOP_LIB!s}
+                ENABLE_DESKTOP_BACKEND=true
+                ACCESS_PASSWORD=restart-probe-password
+                PRIMARY_HOME={primary_home!s}
+                VENV_DIR={root / 'venv'!s}
+                BASE_PATH=/usr/bin:/bin
+                DESKTOP_BACKEND_LAUNCHER={DESKTOP_LAUNCHER!s}
+                DESKTOP_BACKEND_STOP_TIMEOUT=3
+                DESKTOP_BACKEND_PID=""
+                trap desktop_backend_stop EXIT
+                desktop_backend_validate_options
+                desktop_backend_validate_runtime
+                desktop_backend_start
+                for _ in $(seq 1 50); do
+                    if ! kill -0 "$DESKTOP_BACKEND_PID" 2>/dev/null; then break; fi
+                    sleep 0.02
+                done
+                ! kill -0 "$DESKTOP_BACKEND_PID" 2>/dev/null
+                desktop_backend_supervise
+                for _ in $(seq 1 50); do
+                    if [ "$(cat {count_file!s} 2>/dev/null || true)" = "2" ]; then break; fi
+                    sleep 0.02
+                done
+                test "$(cat {count_file!s})" = "2"
+                kill -0 "$DESKTOP_BACKEND_PID"
+                desktop_backend_stop
+                test -z "$DESKTOP_BACKEND_PID"
+                """
+            )
+
+            result = run_bash(script, env=env)
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertIn("Exited (code: 7); restarting", result.stdout)
+            self.assertEqual(count_file.read_text(), "2")
+
+    def test_sigterm_during_started_backend_runs_shutdown_and_stops_child(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            venv_bin = root / "venv" / "bin"
+            venv_bin.mkdir(parents=True)
+            fake_python = venv_bin / "python"
+            fake_python.write_text(
+                textwrap.dedent(
+                    """#!/bin/bash
+                    set -euo pipefail
+                    cat >/dev/null
+                    trap 'exit 0' TERM INT
+                    while :; do sleep 1; done
+                    """
+                )
+            )
+            fake_python.chmod(0o755)
+            fake_hermes = venv_bin / "hermes"
+            fake_hermes.write_text("#!/bin/bash\nprintf '%s\\n' '--skip-build'\n")
+            fake_hermes.chmod(0o755)
+            primary_home = root / "profile"
+            primary_home.mkdir()
+            marker = root / "shutdown-marker"
+            env = {"SIGNAL_MARKER": str(marker)}
+            script = textwrap.dedent(
+                f"""
+                set -euo pipefail
+                source {DESKTOP_LIB!s}
+                ENABLE_DESKTOP_BACKEND=true
+                ACCESS_PASSWORD=signal-probe-password
+                PRIMARY_HOME={primary_home!s}
+                VENV_DIR={root / 'venv'!s}
+                BASE_PATH=/usr/bin:/bin
+                DESKTOP_BACKEND_LAUNCHER={DESKTOP_LAUNCHER!s}
+                DESKTOP_BACKEND_STOP_TIMEOUT=3
+                DESKTOP_BACKEND_PID=""
+                trap desktop_backend_stop EXIT
+                shutdown() {{
+                    desktop_backend_stop
+                    printf 'handled' > "$SIGNAL_MARKER"
+                    exit 0
+                }}
+                trap shutdown SIGTERM SIGINT
+                desktop_backend_validate_options
+                desktop_backend_validate_runtime
+                desktop_backend_start
+                kill -0 "$DESKTOP_BACKEND_PID"
+                kill -TERM $$
+                exit 99
+                """
+            )
+
+            result = run_bash(script, env=env)
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual(marker.read_text(), "handled")
+            self.assertIn("[desktop-backend] Stopped", result.stdout)
+
+    def test_run_script_integrates_validation_start_stop_and_supervision(self) -> None:
+        run_sh = RUN_SH.read_text()
+
+        self.assertIn("ENABLE_DESKTOP_BACKEND=$(opt_bool enable_desktop_backend)", run_sh)
+        self.assertIn("source \"$DESKTOP_BACKEND_LIB\"", run_sh)
+        self.assertIn("desktop_backend_validate_options", run_sh)
+        self.assertIn("desktop_backend_validate_runtime", run_sh)
+        self.assertIn("desktop_backend_start", run_sh)
+        self.assertIn("desktop_backend_stop", run_sh)
+        self.assertIn("desktop_backend_supervise", run_sh)
+        self.assertLess(run_sh.index("shutdown() {"), run_sh.index("trap shutdown SIGTERM SIGINT"))
+        self.assertLess(run_sh.index("trap shutdown SIGTERM SIGINT"), run_sh.index("desktop_backend_start"))
+        self.assertLess(run_sh.index("desktop_backend_stop"), run_sh.index("Gateway stopped"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Purpose

This draft PR exists solely as an independent Devin review surface for the exact feature candidate below. It is not intended to be merged in its current review-only state.

## Summary

- Add an opt-in Hermes Desktop remote backend on container port 9119.
- Keep the feature disabled and the host port unmapped by default.
- Use the official machine-level `hermes serve` backend with Basic auth.
- Make the add-on access password authoritative after Hermes environment loading without exposing plaintext in argv or the post-import auth environment.
- Integrate validate/start/stop/restart/SIGTERM lifecycle handling.
- Document the full-agent-control trust boundary and trusted-network requirement.

## Candidate

- Base: `v1.2.1` / `e00e5f6a2a37346e5fa33501b8e76eb08c390823`
- Feature commit: `2ff4c1c5ef13109e9f4e980bf34a980dda8723f2`
- Release candidate head: `05b4ee7dc0887c992fbf46cf09d417e4e3c9ef09`
- Candidate version: `1.3.0`

## Verification

- 12 focused Desktop-backend tests pass.
- Full repository suite: 66 pass, 1 expected skip when nginx is unavailable locally.
- Shell syntax, Python AST, YAML parsing, public-hygiene scan, and `git diff --check` pass.
- Isolated Hermes 0.18.2 E2E passed for named/sticky profiles, conflicting machine-root credentials, exact edge-whitespace password semantics, authenticated profile access, and WebSocket-ticket minting.

## Release gate

No merge, tag, or release will occur from this draft. The candidate must first pass Devin review and a real isolated Home Assistant DEV add-on build/install/Desktop smoke.

Related: #17
