### PR TITLE
fix: pin ttyd cwd to profile home (-w "$home")

### DIFF
--- a/hermes_agent/run.sh
+++ b/hermes_agent/run.sh
@@ -692,6 +692,7 @@ start_ttyd_for_profile() {
             --interface 127.0.0.1 \
             --base-path "${prefix}/hermes/" \
             --writable -d 3 \
+            -w "$home" \
             tmux -L "hermes-${name}" -u new -A -s "hermes-${name}" /usr/local/bin/start-hermes &
     TTYD_HERMES_PIDS[$i]=$!
 
@@ -701,6 +702,7 @@ start_ttyd_for_profile() {
             --interface 127.0.0.1 \
             --base-path "${prefix}/terminal/" \
             --writable -d 3 \
+            -w "$home" \
             tmux -L "terminal-${name}" -u new -A -s "terminal-${name}" /usr/bin/bash &
     TTYD_TERMINAL_PIDS[$i]=$!
     echo "[run] [$name] ttyd PIDs: hermes=${TTYD_HERMES_PIDS[$i]} terminal=${TTYD_TERMINAL_PIDS[$i]}"

--- a/tests/test_multi_profile.py
+++ b/tests/test_multi_profile.py
@@ -624,5 +624,35 @@ class RenderedConfigTests(unittest.TestCase):
         )
 
 
+class RunScriptTtydCwdTests(unittest.TestCase):
+    """Each ttyd invocation in run.sh must pin the working directory to the
+    profile home (-w "$home"), otherwise web terminals (and sessions created
+    through them / adopted by the desktop app via session.info) start in "/"
+    instead of the profile home."""
+
+    RUN_SH = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "hermes_agent", "run.sh")
+
+    def setUp(self):
+        with open(self.RUN_SH, encoding="utf-8") as f:
+            self.run_sh = f.read()
+
+    def test_ttyd_hermes_invocation_pins_cwd(self):
+        # The hermes (chat) ttyd must pass -w "$home" before tmux.
+        block = self.run_sh.split("start_ttyd_for_profile()", 1)[1].split("TTYD_HERMES_PIDS[$i]=$!", 1)[0]
+        self.assertIn('-w "$home"', block, "hermes ttyd invocation missing -w \"$home\"")
+
+    def test_ttyd_terminal_invocation_pins_cwd(self):
+        # The terminal ttyd must pass -w "$home" before tmux.
+        block = self.run_sh.split("TTYD_HERMES_PIDS[$i]=$!", 1)[1].split("TTYD_TERMINAL_PIDS[$i]=$!", 1)[0]
+        self.assertIn('-w "$home"', block, "terminal ttyd invocation missing -w \"$home\"")
+
+    def test_both_invocations_place_cwd_before_tmux(self):
+        # -w must be attached to ttyd (not after the command) so ttyd applies it.
+        for needle in ("tmux -L \"hermes-", "tmux -L \"terminal-"):
+            idx = self.run_sh.index(needle)
+            preceding = self.run_sh[max(0, idx - 60):idx]
+            self.assertIn('-w "$home"', preceding, f"-w \"$home\" not before {needle}")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Problem
Web terminals (ttyd) start with cwd `/` (container root) instead of the profile home. Sessions created through those terminals, and sessions adopted by the desktop app via `session.info.cwd`, inherit `/` — so `terminal.cwd` from the profile config never applies because the desktop always sends its own cwd on `session.create`.

## Fix
Add `-w "\$home"` to both ttyd invocations in `start_ttyd_for_profile()` (hermes chat + terminal). ttyd supports `-w, --cwd` — `Working directory to be set for the child program`.

## Tests
Added `RunScriptTtydCwdTests` (3 cases) asserting both invocations pin cwd before tmux. Verified: fails 3/3 on main, passes with fix. Full suite: 36/36 OK.