### PR TITLE
Fix gateway supervision runtime health

### DIFF
--- a/hermes_agent/CHANGELOG.md
+++ b/hermes_agent/CHANGELOG.md
@@ -6,6 +6,11 @@ The format follows the spirit of [Keep a Changelog](https://keepachangelog.com/e
 
 ## [Unreleased]
 
+### Fixed
+
+- Reduce Linux gateway-supervisor process-tree snapshots from 20 per second to one every two seconds while preserving 50 ms exit and signal responsiveness, immediate cleanup scans, and the existing non-Linux containment behavior.
+- Publish add-on launcher processes with the recognized `hermes-gateway` command identity so Hermes Dashboard liveness correctly reports s6-supervised gateways as running.
+
 ## [1.3.1] - 2026-07-31
 
 ### Fixed

--- a/hermes_agent/gateway-supervisor.py
+++ b/hermes_agent/gateway-supervisor.py
@@ -14,6 +14,7 @@ import tempfile
 import time
 
 _POLL_SECONDS = 0.05
+_DESCENDANT_SCAN_SECONDS = 2.0
 _GATEWAY_GRACE_SECONDS = 5.0
 _DESCENDANT_GRACE_SECONDS = 2.0
 _PR_SET_PDEATHSIG = 1
@@ -233,7 +234,8 @@ def supervise(
 ) -> int:
     """Run one gateway and return only after all of its descendants are gone."""
     gateway = subprocess.Popen(
-        [python_path, launcher, "gateway", "run"],
+        ["hermes-gateway", launcher, "gateway", "run"],
+        executable=python_path,
         close_fds=True,
         env=gateway_environment,
     )
@@ -241,12 +243,19 @@ def supervise(
     known: set[int] = {gateway.pid}
     stop_forwarded = False
     stop_deadline: float | None = None
+    next_descendant_scan = 0.0
+    descendant_scan_seconds = (
+        _DESCENDANT_SCAN_SECONDS if sys.platform == "linux" else _POLL_SECONDS
+    )
 
     while gateway.poll() is None:
-        parents = _process_parents()
-        known.update(_descendants(gateway.pid, parents))
-        known.update(_descendants(os.getpid(), parents))
-        known.discard(os.getpid())
+        now = time.monotonic()
+        if now >= next_descendant_scan:
+            parents = _process_parents()
+            known.update(_descendants(gateway.pid, parents))
+            known.update(_descendants(os.getpid(), parents))
+            known.discard(os.getpid())
+            next_descendant_scan = now + descendant_scan_seconds
 
         if _stop_signal is not None and not stop_forwarded:
             try:

--- a/tests/test_dashboard_ingress_patches.py
+++ b/tests/test_dashboard_ingress_patches.py
@@ -11,6 +11,7 @@ import tempfile
 import textwrap
 import time
 import unittest
+from unittest import mock
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -319,6 +320,113 @@ class DashboardIngressPatchTests(unittest.TestCase):
         self.assertIn("/usr/local/lib/hermes-gateway-child.sh", dockerfile)
         self.assertIn("/usr/local/lib/hermes-gateway-supervisor.py", dockerfile)
         self.assertIn("/usr/local/lib/hermes-gateway-logger.py", dockerfile)
+
+    def test_gateway_supervisor_throttles_expensive_descendant_scans(self) -> None:
+        namespace = runpy.run_path(
+            str(GATEWAY_SUPERVISOR), run_name="gateway_supervisor_test"
+        )
+        supervise = namespace["supervise"]
+        function_globals = supervise.__globals__
+        clock = [0.0]
+        snapshots = 0
+
+        class FakeGateway:
+            pid = 4321
+
+            def __init__(self) -> None:
+                self.poll_count = 0
+
+            def poll(self) -> int | None:
+                self.poll_count += 1
+                return None if self.poll_count <= 50 else 0
+
+            def wait(self) -> int:
+                return 0
+
+        gateway = FakeGateway()
+
+        def process_parents() -> dict[int, int]:
+            nonlocal snapshots
+            snapshots += 1
+            return {}
+
+        def sleep(seconds: float) -> None:
+            clock[0] += seconds
+
+        with (
+            mock.patch.dict(
+                function_globals,
+                {
+                    "_process_parents": process_parents,
+                    "_cleanup_owned_descendants": lambda _known: None,
+                    "_stop_signal": None,
+                },
+            ),
+            mock.patch.object(
+                function_globals["sys"], "platform", "linux"
+            ),
+            mock.patch.object(
+                function_globals["subprocess"], "Popen", return_value=gateway
+            ),
+            mock.patch.object(
+                function_globals["time"], "monotonic", side_effect=lambda: clock[0]
+            ),
+            mock.patch.object(function_globals["time"], "sleep", side_effect=sleep),
+        ):
+            result = supervise(
+                "/venv/bin/python",
+                "/usr/local/lib/hermes-gateway-launcher.py",
+                {},
+            )
+
+        self.assertEqual(result, 0)
+        self.assertEqual(gateway.poll_count, 51)
+        self.assertLessEqual(snapshots, 2)
+
+    def test_gateway_supervisor_publishes_recognizable_gateway_argv0(self) -> None:
+        namespace = runpy.run_path(
+            str(GATEWAY_SUPERVISOR), run_name="gateway_supervisor_test"
+        )
+        supervise = namespace["supervise"]
+        function_globals = supervise.__globals__
+
+        class ExitedGateway:
+            pid = 4321
+
+            def poll(self) -> int:
+                return 0
+
+            def wait(self) -> int:
+                return 0
+
+        with (
+            mock.patch.object(
+                function_globals["subprocess"],
+                "Popen",
+                return_value=ExitedGateway(),
+            ) as popen,
+            mock.patch.dict(
+                function_globals,
+                {"_cleanup_owned_descendants": lambda _known: None},
+            ),
+        ):
+            supervise(
+                "/venv/bin/python",
+                "/usr/local/lib/hermes-gateway-launcher.py",
+                {},
+            )
+
+        positional, keyword = popen.call_args
+        self.assertEqual(
+            positional[0],
+            [
+                "hermes-gateway",
+                "/usr/local/lib/hermes-gateway-launcher.py",
+                "gateway",
+                "run",
+            ],
+        )
+        self.assertEqual(keyword["executable"], "/venv/bin/python")
 
     def test_gateway_spawn_defers_shutdown_until_ownership_is_published(self) -> None:
         run_text = RUN_SH.read_text()


### PR DESCRIPTION
## Summary

- throttle Linux descendant-process snapshots from every 50 ms to once every two seconds
- preserve the 50 ms gateway exit and signal polling cadence and unthrottled final cleanup
- identify launcher-supervised gateway children with the semantic `hermes-gateway` argv0 so existing Hermes liveness checks recognize them

## Testing

- 108 tests passed, 2 skipped, 69 subtests passed
- Python and shell syntax checks
- focused scan-throttling, containment, argv0, and real child-process checks

Fixes #33
Fixes #34
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wolframravenwolf/hermes-ha-addon/pull/37" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->