### PR TITLE
fix: exclude rebuildable data from Home Assistant backups

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,12 @@ The Hermes tab uses a dedicated `start-hermes` wrapper (sources .bashrc, starts 
 
 Inside the add-on container, `~` is `/config`. That path is the add-on's private `addon_config` mount, not the normal Home Assistant Core `/config` folder. It survives add-on updates and is included in Home Assistant backups.
 
+### Home Assistant backups
+
+Home Assistant backups exclude only rebuildable Hermes runtime dependencies and caches: the shared Python venv, project and dashboard `node_modules`, each profile's LSP `node_modules`, `.cache`, and `.npm`. The shared runtime dependencies are regenerated during startup, while caches repopulate when needed. LSP packages are reinstalled automatically on first LSP use when auto-install is enabled; with a manual install strategy, run `hermes lsp install <server-id>`. The first start or first LSP use after a restore can therefore be slower and network-dependent while dependencies are downloaded again.
+
+Canonical source and profile state remain backed up, including local source changes, configuration, credentials, state databases, sessions, memories, skills, plugins, and secrets. User-managed tools and browser profiles/login state also remain backed up, including Homebrew, global npm, Go, Bun, certificates, and shell configuration.
+
 From the HAOS host or Samba, look for the `addon_configs` share/folder. The host-side path usually looks like this:
 
 ```text

--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ Inside the add-on container, `~` is `/config`. That path is the add-on's private
 
 ### Home Assistant backups
 
-Home Assistant backups exclude only rebuildable Hermes runtime dependencies and caches: the shared Python venv, project and dashboard `node_modules`, each profile's LSP `node_modules`, `.cache`, and `.npm`. The shared runtime dependencies are regenerated during startup, while caches repopulate when needed. LSP packages are reinstalled automatically on first LSP use when auto-install is enabled; with a manual install strategy, run `hermes lsp install <server-id>`. The first start or first LSP use after a restore can therefore be slower and network-dependent while dependencies are downloaded again.
+Home Assistant backups exclude only rebuildable Hermes runtime dependencies and caches: the shared Python venv, project and dashboard `node_modules`, each profile's generated LSP runtimes, `.cache`, and `.npm`. The shared runtime dependencies are regenerated during startup, while caches repopulate when needed. LSP packages are reinstalled automatically on first LSP use when auto-install is enabled; with a manual install strategy, run `hermes lsp install <server-id>`. The first start or first LSP use after a restore can therefore be slower and network-dependent while dependencies are downloaded again.
 
 Canonical source and profile state remain backed up, including local source changes, configuration, credentials, state databases, sessions, memories, skills, plugins, and secrets. User-managed tools and browser profiles/login state also remain backed up, including Homebrew, global npm, Go, Bun, certificates, and shell configuration.
 

--- a/hermes_agent/CHANGELOG.md
+++ b/hermes_agent/CHANGELOG.md
@@ -6,6 +6,10 @@ The format follows the spirit of [Keep a Changelog](https://keepachangelog.com/e
 
 ## [Unreleased]
 
+### Changed
+
+- Reduce backup size by excluding only regenerated shared venv, project/dashboard dependencies, profile LSP dependencies, and `.cache`/`.npm` caches. The first start or first LSP use after a restore can be slower and network-dependent; canonical state, user-managed tools, and browser profiles/login state remain backed up.
+
 ### Fixed
 
 - Reduce Linux gateway-supervisor process-tree snapshots from 20 per second to one every two seconds while preserving 50 ms exit and signal responsiveness, immediate cleanup scans, and the existing non-Linux containment behavior.

--- a/hermes_agent/CHANGELOG.md
+++ b/hermes_agent/CHANGELOG.md
@@ -8,12 +8,13 @@ The format follows the spirit of [Keep a Changelog](https://keepachangelog.com/e
 
 ### Changed
 
-- Reduce backup size by excluding only regenerated shared venv, project/dashboard dependencies, profile LSP dependencies, and `.cache`/`.npm` caches. The first start or first LSP use after a restore can be slower and network-dependent; canonical state, user-managed tools, and browser profiles/login state remain backed up.
+- Reduce backup size by excluding only regenerated shared venv, project/dashboard dependencies, profile LSP runtimes, and `.cache`/`.npm` caches. The first start or first LSP use after a restore can be slower and network-dependent; canonical state, user-managed tools, and browser profiles/login state remain backed up.
 
 ### Fixed
 
 - Reduce Linux gateway-supervisor process-tree snapshots from 20 per second to one every two seconds while preserving 50 ms exit and signal responsiveness, immediate cleanup scans, and the existing non-Linux containment behavior.
 - Publish add-on launcher processes with the recognized `hermes-gateway` command identity so Hermes Dashboard liveness correctly reports s6-supervised gateways as running.
+- Preserve Linux virtualenv discovery while publishing that identity by starting a venv-local `hermes-gateway` interpreter symlink directly; this prevents startup from losing installed packages such as `hermes_cli`.
 
 ## [1.3.1] - 2026-07-31
 

--- a/hermes_agent/config.yaml
+++ b/hermes_agent/config.yaml
@@ -14,6 +14,13 @@ ingress_port: 49169
 ingress_stream: true
 panel_icon: mdi:robot
 panel_title: Hermes Agent
+backup_exclude:
+  - .hermes/hermes-agent/venv
+  - .hermes/hermes-agent/node_modules
+  - .hermes/hermes-agent/web/node_modules
+  - lsp/node_modules
+  - .cache
+  - .npm
 map:
   - addon_config:rw
   - media:rw

--- a/hermes_agent/config.yaml
+++ b/hermes_agent/config.yaml
@@ -18,7 +18,10 @@ backup_exclude:
   - .hermes/hermes-agent/venv
   - .hermes/hermes-agent/node_modules
   - .hermes/hermes-agent/web/node_modules
+  - lsp/bin
   - lsp/node_modules
+  - lsp/python-packages
+  - lsp/pses
   - .cache
   - .npm
 map:

--- a/hermes_agent/gateway-supervisor.py
+++ b/hermes_agent/gateway-supervisor.py
@@ -234,8 +234,7 @@ def supervise(
 ) -> int:
     """Run one gateway and return only after all of its descendants are gone."""
     gateway = subprocess.Popen(
-        ["hermes-gateway", launcher, "gateway", "run"],
-        executable=python_path,
+        [python_path, launcher, "gateway", "run"],
         close_fds=True,
         env=gateway_environment,
     )

--- a/hermes_agent/run.sh
+++ b/hermes_agent/run.sh
@@ -442,6 +442,16 @@ install_hermes_core() {
 
 install_hermes_core
 
+# Keep the gateway process recognizable to Hermes core without replacing
+# Python's argv[0] with a name that breaks Linux venv discovery. A relative
+# symlink stays valid when the persisted add-on config is restored elsewhere.
+GATEWAY_PYTHON="$VENV_DIR/bin/hermes-gateway"
+if [ -e "$GATEWAY_PYTHON" ] && [ ! -L "$GATEWAY_PYTHON" ]; then
+    echo "[run] FATAL: reserved gateway interpreter path already exists" >&2
+    exit 1
+fi
+ln -snf python "$GATEWAY_PYTHON"
+
 # Activate the shared venv for any tooling (e.g. dashboard module probe).
 # shellcheck disable=SC1091
 source "$VENV_DIR/bin/activate"
@@ -741,7 +751,7 @@ start_gateway_for_profile() {
             export HERMES_ADDON_API_KEY=""
         fi
         exec "$GATEWAY_CHILD" \
-            "$VENV_DIR/bin/python" \
+            "$GATEWAY_PYTHON" \
             "$GATEWAY_SUPERVISOR" \
             "$GATEWAY_LAUNCHER" \
             "$ready_file" \

--- a/tests/test_api_server_config.py
+++ b/tests/test_api_server_config.py
@@ -815,9 +815,6 @@ class PublicationMetadataTests(unittest.TestCase):
 
     def test_release_changelog_records_actual_verification(self):
         changelog = CHANGELOG.read_text()
-        unreleased = changelog.split("## [Unreleased]", 1)[1].split("\n## [", 1)[0]
-        self.assertEqual(unreleased.strip(), "")
-
         release = changelog.split("## [1.3.1] - 2026-07-31", 1)[1].split(
             "\n## [", 1
         )[0]

--- a/tests/test_backup_policy.py
+++ b/tests/test_backup_policy.py
@@ -1,0 +1,230 @@
+"""Backup policy contracts for the Hermes Agent Home Assistant add-on."""
+
+import os
+import shlex
+import subprocess
+import sys
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[1]
+ADDON = ROOT / "hermes_agent"
+CONFIG = ADDON / "config.yaml"
+RUN_SCRIPT = ADDON / "run.sh"
+CHANGELOG = ADDON / "CHANGELOG.md"
+README = ROOT / "README.md"
+
+BASH = "/bin/bash" if sys.platform == "darwin" and os.path.exists("/bin/bash") else "bash"
+
+EXPECTED_BACKUP_EXCLUDE = [
+    ".hermes/hermes-agent/venv",
+    ".hermes/hermes-agent/node_modules",
+    ".hermes/hermes-agent/web/node_modules",
+    "lsp/node_modules",
+    ".cache",
+    ".npm",
+]
+
+
+def _manifest():
+    return yaml.safe_load(CONFIG.read_text())
+
+
+def _excluded_with_supervisor_pruning(full_path, patterns):
+    """Model Supervisor's Path(full_path).match(pattern) directory pruning."""
+    path = Path(full_path)
+    for depth in range(1, len(path.parts) + 1):
+        candidate = Path(*path.parts[:depth])
+        if any(candidate.match(pattern) for pattern in patterns):
+            return True
+    return False
+
+
+def _installation_functions():
+    run = RUN_SCRIPT.read_text()
+    start = run.index("compute_marker() {")
+    end = run.index("\ninstall_hermes_core() {", start)
+    return run[start:end]
+
+
+class BackupManifestTests(unittest.TestCase):
+    def test_manifest_has_exact_conservative_backup_exclude_allowlist(self):
+        self.assertEqual(_manifest().get("backup_exclude"), EXPECTED_BACKUP_EXCLUDE)
+
+    def test_manifest_preserves_hot_backup_mode(self):
+        self.assertNotIn("backup", _manifest())
+
+    def test_supervisor_matching_prunes_rebuildable_runtime_directories(self):
+        patterns = _manifest().get("backup_exclude", ())
+        excluded_paths = {
+            "shared venv": "/config/.hermes/hermes-agent/venv",
+            "shared venv descendant": "/config/.hermes/hermes-agent/venv/bin/python",
+            "shared node modules": "/config/.hermes/hermes-agent/node_modules/agent-browser",
+            "dashboard node modules": (
+                "/config/.hermes/hermes-agent/web/node_modules/vite/bin/vite.js"
+            ),
+            "default profile LSP": "/config/.hermes/lsp/node_modules/typescript/lib/tsserver.js",
+            "named profile LSP": (
+                "/config/.hermes/profiles/amy/lsp/node_modules/typescript/lib/tsserver.js"
+            ),
+            "custom-base profile LSP": (
+                "/config/custom/profiles/research/lsp/node_modules/typescript/lib/tsserver.js"
+            ),
+            "legacy-flat profile LSP": (
+                "/config/amy/lsp/node_modules/typescript/lib/tsserver.js"
+            ),
+            "cache": "/config/.cache/uv/archive-v0/package",
+            "npm cache": "/config/.npm/_cacache/content-v2/package",
+        }
+        for label, path in excluded_paths.items():
+            with self.subTest(label=label, path=path):
+                self.assertTrue(
+                    _excluded_with_supervisor_pruning(path, patterns),
+                    f"Supervisor would not prune {path}",
+                )
+
+    def test_supervisor_matching_keeps_durable_state_and_user_toolchains(self):
+        patterns = _manifest().get("backup_exclude", ())
+        retained_paths = {
+            "source": "/config/.hermes/hermes-agent/hermes_cli/main.py",
+            "source git": "/config/.hermes/hermes-agent/.git/objects/aa/object",
+            "profile config": "/config/.hermes/config.yaml",
+            "profile environment": "/config/.hermes/.env",
+            "profile auth": "/config/.hermes/auth.json",
+            "state database": "/config/.hermes/state.db",
+            "sessions": "/config/.hermes/sessions/session.json",
+            "memories": "/config/.hermes/memories/MEMORY.md",
+            "skills": "/config/.hermes/skills/custom/SKILL.md",
+            "plugins": "/config/.hermes/plugins/custom/plugin.py",
+            "secrets": "/config/.hermes/secrets.yaml",
+            "homebrew": "/config/.linuxbrew/Cellar/node/22/bin/node",
+            "global npm": (
+                "/config/.npm-global/lib/node_modules/typescript/lib/tsserver.js"
+            ),
+            "go": "/config/.go/pkg/mod/example.org/tool/source.go",
+            "bun": "/config/.bun/install/cache/tool/package.json",
+            "Camofox login state": (
+                "/config/.camofox/profiles/user-hash/storage_state.json"
+            ),
+            "Chrome debug login state": (
+                "/config/.hermes/chrome-debug/Default/Login Data"
+            ),
+            "certificates": "/config/.certs/server.key",
+            "shell config": "/config/.bashrc",
+            "similarly named cache": "/config/.cache-user/index",
+            "npm configuration": "/config/.npmrc",
+        }
+        for label, path in retained_paths.items():
+            with self.subTest(label=label, path=path):
+                self.assertFalse(
+                    _excluded_with_supervisor_pruning(path, patterns),
+                    f"Supervisor would unexpectedly prune {path}",
+                )
+
+
+class ReconstructionContractTests(unittest.TestCase):
+    def test_missing_excluded_shared_venv_requires_reinstallation(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            home = Path(tmp) / "home"
+            source = home / ".hermes" / "hermes-agent"
+            venv = source / "venv"
+            marker = home / ".hermes_install"
+            (source / ".git").mkdir(parents=True)
+            (source / "mini-swe-agent").mkdir()
+            (source / "mini-swe-agent" / "pyproject.toml").write_text(
+                "[project]\nname = 'retained-source'\n"
+            )
+            (venv / "bin").mkdir(parents=True)
+            (venv / "bin" / "activate").write_text("")
+            (venv / "bin" / "hermes").write_text("")
+
+            script = textwrap.dedent(
+                f"""
+                set -euo pipefail
+                GIT_URL=https://example.invalid/hermes-agent.git
+                GIT_REF=retained-ref
+                SRC_DIR={shlex.quote(str(source))}
+                VENV_DIR={shlex.quote(str(venv))}
+                MARKER_FILE={shlex.quote(str(marker))}
+
+                {_installation_functions()}
+
+                compute_marker() {{
+                    printf 'retained-marker\\n'
+                }}
+                compute_marker > "$MARKER_FILE"
+                if install_needed; then
+                    printf 'unexpected-install-needed-before-removal\\n' >&2
+                    exit 10
+                fi
+                printf 'UP_TO_DATE\\n'
+
+                rm -rf "$VENV_DIR"
+                if install_needed; then
+                    printf 'INSTALL_NEEDED\\n'
+                else
+                    printf 'unexpected-up-to-date-after-removal\\n' >&2
+                    exit 11
+                fi
+                """
+            )
+            result = subprocess.run(
+                [BASH, "-c", script],
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual(result.stdout, "UP_TO_DATE\nINSTALL_NEEDED\n")
+            self.assertTrue(source.is_dir())
+            self.assertTrue(marker.is_file())
+            self.assertFalse(venv.exists())
+
+
+class BackupDocumentationTests(unittest.TestCase):
+    def test_readme_explains_backup_reconstruction_and_retention(self):
+        readme = README.read_text()
+        self.assertIn("### Home Assistant backups", readme)
+        backup_section = readme.split("### Home Assistant backups", 1)[1]
+        backup_section = backup_section.split("\n### ", 1)[0].lower()
+        for phrase in (
+            "regenerated",
+            "slower",
+            "network",
+            "first lsp use",
+            "hermes lsp install",
+            "user-managed tools",
+            "login state",
+            "remain backed up",
+        ):
+            with self.subTest(phrase=phrase):
+                self.assertIn(phrase, backup_section)
+        self.assertNotIn(
+            "excluded paths are regenerated during startup",
+            backup_section,
+        )
+
+    def test_changelog_records_backup_reconstruction_and_retention(self):
+        unreleased = CHANGELOG.read_text().split("## [Unreleased]", 1)[1]
+        unreleased = unreleased.split("\n## [", 1)[0].lower()
+        for phrase in (
+            "regenerated",
+            "slower",
+            "network",
+            "first lsp use",
+            "user-managed tools",
+            "login state",
+            "remain backed up",
+        ):
+            with self.subTest(phrase=phrase):
+                self.assertIn(phrase, unreleased)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_backup_policy.py
+++ b/tests/test_backup_policy.py
@@ -25,7 +25,10 @@ EXPECTED_BACKUP_EXCLUDE = [
     ".hermes/hermes-agent/venv",
     ".hermes/hermes-agent/node_modules",
     ".hermes/hermes-agent/web/node_modules",
+    "lsp/bin",
     "lsp/node_modules",
+    "lsp/python-packages",
+    "lsp/pses",
     ".cache",
     ".npm",
 ]
@@ -69,8 +72,16 @@ class BackupManifestTests(unittest.TestCase):
                 "/config/.hermes/hermes-agent/web/node_modules/vite/bin/vite.js"
             ),
             "default profile LSP": "/config/.hermes/lsp/node_modules/typescript/lib/tsserver.js",
+            "default profile LSP wrapper": "/config/.hermes/lsp/bin/pyright-langserver",
+            "default profile Python LSP package": (
+                "/config/.hermes/lsp/python-packages/pylsp/__init__.py"
+            ),
+            "default profile LSP scratch": "/config/.hermes/lsp/pses/pses.log",
             "named profile LSP": (
                 "/config/.hermes/profiles/amy/lsp/node_modules/typescript/lib/tsserver.js"
+            ),
+            "named profile LSP wrapper": (
+                "/config/.hermes/profiles/amy/lsp/bin/pyright-langserver"
             ),
             "custom-base profile LSP": (
                 "/config/custom/profiles/research/lsp/node_modules/typescript/lib/tsserver.js"
@@ -92,6 +103,7 @@ class BackupManifestTests(unittest.TestCase):
         patterns = _manifest().get("backup_exclude", ())
         retained_paths = {
             "source": "/config/.hermes/hermes-agent/hermes_cli/main.py",
+            "Hermes LSP source": "/config/.hermes/hermes-agent/agent/lsp/manager.py",
             "source git": "/config/.hermes/hermes-agent/.git/objects/aa/object",
             "profile config": "/config/.hermes/config.yaml",
             "profile environment": "/config/.hermes/.env",
@@ -106,6 +118,8 @@ class BackupManifestTests(unittest.TestCase):
             "global npm": (
                 "/config/.npm-global/lib/node_modules/typescript/lib/tsserver.js"
             ),
+            "external user-managed LSP": "/config/.local/bin/pyright-langserver",
+            "user directory named LSP": "/config/projects/lsp/README.md",
             "go": "/config/.go/pkg/mod/example.org/tool/source.go",
             "bun": "/config/.bun/install/cache/tool/package.json",
             "Camofox login state": (
@@ -198,6 +212,7 @@ class BackupDocumentationTests(unittest.TestCase):
             "slower",
             "network",
             "first lsp use",
+            "lsp runtimes",
             "hermes lsp install",
             "user-managed tools",
             "login state",
@@ -205,6 +220,7 @@ class BackupDocumentationTests(unittest.TestCase):
         ):
             with self.subTest(phrase=phrase):
                 self.assertIn(phrase, backup_section)
+        self.assertNotIn("lsp `node_modules`", backup_section)
         self.assertNotIn(
             "excluded paths are regenerated during startup",
             backup_section,

--- a/tests/test_dashboard_ingress_patches.py
+++ b/tests/test_dashboard_ingress_patches.py
@@ -383,7 +383,7 @@ class DashboardIngressPatchTests(unittest.TestCase):
         self.assertEqual(gateway.poll_count, 51)
         self.assertLessEqual(snapshots, 2)
 
-    def test_gateway_supervisor_publishes_recognizable_gateway_argv0(self) -> None:
+    def test_gateway_supervisor_uses_recognizable_venv_executable(self) -> None:
         namespace = runpy.run_path(
             str(GATEWAY_SUPERVISOR), run_name="gateway_supervisor_test"
         )
@@ -411,7 +411,7 @@ class DashboardIngressPatchTests(unittest.TestCase):
             ),
         ):
             supervise(
-                "/venv/bin/python",
+                "/venv/bin/hermes-gateway",
                 "/usr/local/lib/hermes-gateway-launcher.py",
                 {},
             )
@@ -420,13 +420,18 @@ class DashboardIngressPatchTests(unittest.TestCase):
         self.assertEqual(
             positional[0],
             [
-                "hermes-gateway",
+                "/venv/bin/hermes-gateway",
                 "/usr/local/lib/hermes-gateway-launcher.py",
                 "gateway",
                 "run",
             ],
         )
-        self.assertEqual(keyword["executable"], "/venv/bin/python")
+        self.assertNotIn("executable", keyword)
+
+    def test_run_creates_recognizable_gateway_link_inside_venv(self) -> None:
+        run_text = RUN_SH.read_text()
+        self.assertIn('GATEWAY_PYTHON="$VENV_DIR/bin/hermes-gateway"', run_text)
+        self.assertIn('ln -snf python "$GATEWAY_PYTHON"', run_text)
 
     def test_gateway_spawn_defers_shutdown_until_ownership_is_published(self) -> None:
         run_text = RUN_SH.read_text()


### PR DESCRIPTION
## Summary

- keep Home Assistant hot-backup behavior unchanged
- exclude only nine generated dependency/cache paths through `backup_exclude`
- preserve Hermes source, profiles, configuration, credentials, sessions, memories, skills, plugins, browser login state, certificates, shell configuration, and user-managed toolchains
- remove every Hermes-generated LSP package/wrapper subtree together so stale wrappers cannot suppress first-use reconstruction
- preserve Linux virtualenv discovery while retaining the recognized `hermes-gateway` process identity
- document slower and potentially network-dependent reconstruction after restore
- add focused tests for Supervisor path matching, durable-state retention, startup reconstruction, and gateway interpreter identity

## Excluded paths

```yaml
backup_exclude:
  - .hermes/hermes-agent/venv
  - .hermes/hermes-agent/node_modules
  - .hermes/hermes-agent/web/node_modules
  - lsp/bin
  - lsp/node_modules
  - lsp/python-packages
  - lsp/pses
  - .cache
  - .npm
```

The shared Python environment and project/dashboard dependencies are rebuilt during startup when missing. Caches repopulate on demand. Generated LSP wrappers and packages are reinstalled automatically on first LSP use when automatic installation is enabled, or manually with `hermes lsp install <server-id>`.

The broader `.linuxbrew`, `.npm-global`, Go, Bun, and other user-managed toolchain directories remain backed up because they can contain durable user-installed software rather than disposable caches. Source and user directories merely named `lsp` remain included.

## Verification

- focused backup-policy tests: 7 passed
- full unit test discovery: 118 passed, 2 environment-dependent tests skipped
- all add-on shell scripts passed `bash -n`
- Python/YAML validation and `git diff --check` passed
- current-head Devin review: 0 bugs; 3 independently checked non-blocking analyses
- real HAOS Linux gateway probe confirmed the Venv-local `hermes-gateway -> python` interpreter imports installed Hermes packages and publishes exactly one final launcher process
- real Home Assistant Supervisor partial hot backup contained exactly the disposable test add-on; PID-1 start identity stayed unchanged across backup
- secret-safe archive inspection checked 19,468 inner members: all 9 durable canary categories present, 0 excluded markers, and 0 descendants under excluded subtrees
- post-backup durable mutation plus uninstall-with-config-retention were followed by one partial restore job, which completed successfully and returned the pre-backup durable state
- restored startup rebuilt the Python environment and reached full service readiness
- real first-use `LSPService.snapshot_baseline()` rebuilt Pyright from an initially absent LSP runtime without modifying the target file or marking the service pair broken
- cleanup removed the test backup, app, config, container, and temporary repository; production add-on state/options and the original backup inventory remained unchanged

Closes #36

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wolframravenwolf/hermes-ha-addon/pull/38" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
