### PR TITLE
fix: preserve gateway slot supervisor ownership

### DIFF
--- a/hermes_agent/CHANGELOG.md
+++ b/hermes_agent/CHANGELOG.md
@@ -15,6 +15,7 @@ The format follows the spirit of [Keep a Changelog](https://keepachangelog.com/e
 - Reduce Linux gateway-supervisor process-tree snapshots from 20 per second to one every two seconds while preserving 50 ms exit and signal responsiveness, immediate cleanup scans, and the existing non-Linux containment behavior.
 - Publish add-on launcher processes with the recognized `hermes-gateway` command identity so Hermes Dashboard liveness correctly reports s6-supervised gateways as running.
 - Preserve Linux virtualenv discovery while publishing that identity by starting a venv-local `hermes-gateway` interpreter symlink directly; this prevents startup from losing installed packages such as `hermes_cli`.
+- Keep the per-slot supervisor out of Hermes gateway process discovery by running it through ordinary venv Python and deriving the recognizable `hermes-gateway` alias only for the final child; status and update flows no longer treat the supervisor as an extra manual gateway, and updates hand the runtime back to the slot supervisor instead of launching a detached restart watcher.
 
 ## [1.3.1] - 2026-07-31
 

--- a/hermes_agent/gateway-child.sh
+++ b/hermes_agent/gateway-child.sh
@@ -14,4 +14,4 @@ ready_path="$4"
 parent_pid="$5"
 
 exec "$python_path" "$supervisor" \
-    "$python_path" "$launcher" "$ready_path" "$parent_pid"
+    "$launcher" "$ready_path" "$parent_pid"

--- a/hermes_agent/gateway-supervisor.py
+++ b/hermes_agent/gateway-supervisor.py
@@ -234,7 +234,13 @@ def supervise(
 ) -> int:
     """Run one gateway and return only after all of its descendants are gone."""
     gateway = subprocess.Popen(
-        [python_path, launcher, "gateway", "run"],
+        [
+            python_path,
+            launcher,
+            "gateway",
+            "run",
+            "--external-supervisor",
+        ],
         close_fds=True,
         env=gateway_environment,
     )
@@ -288,15 +294,14 @@ def main() -> int:
     if not resumed:
         signal.pthread_sigmask(signal.SIG_BLOCK, _BOOTSTRAP_SIGNALS)
         initial_arguments = sys.argv[1:]
-        if len(initial_arguments) != 4:
+        if len(initial_arguments) != 3:
             print(
-                "gateway-supervisor.py: expected PYTHON LAUNCHER READY_PATH "
-                "PARENT_PID",
+                "gateway-supervisor.py: expected LAUNCHER READY_PATH PARENT_PID",
                 file=sys.stderr,
             )
             return 64
         try:
-            expected_parent_pid = int(initial_arguments[3])
+            expected_parent_pid = int(initial_arguments[2])
             if os.getpgrp() != os.getpid():
                 os.setsid()
             _set_linux_process_contract(expected_parent_pid)
@@ -308,11 +313,12 @@ def main() -> int:
 
     try:
         gateway_environment, arguments = _load_gateway_environment()
-        if len(arguments) != 4:
+        if len(arguments) != 3:
             raise RuntimeError(
-                "expected PYTHON LAUNCHER READY_PATH PARENT_PID after re-exec"
+                "expected LAUNCHER READY_PATH PARENT_PID after re-exec"
             )
-        python_path, launcher, ready_path, parent_pid_text = arguments
+        launcher, ready_path, parent_pid_text = arguments
+        gateway_executable = str(Path(sys.executable).with_name("hermes-gateway"))
         expected_parent_pid = int(parent_pid_text)
         _set_linux_process_contract(expected_parent_pid)
         signal.pthread_sigmask(signal.SIG_UNBLOCK, _BOOTSTRAP_SIGNALS)
@@ -321,7 +327,7 @@ def main() -> int:
         _publish_ready(ready_path)
         if _stop_signal is not None:
             return 0
-        return supervise(python_path, launcher, gateway_environment)
+        return supervise(gateway_executable, launcher, gateway_environment)
     except (OSError, RuntimeError, ValueError, subprocess.SubprocessError) as error:
         print(f"gateway-supervisor: {error}", file=sys.stderr, flush=True)
         return 70

--- a/hermes_agent/run.sh
+++ b/hermes_agent/run.sh
@@ -751,7 +751,7 @@ start_gateway_for_profile() {
             export HERMES_ADDON_API_KEY=""
         fi
         exec "$GATEWAY_CHILD" \
-            "$GATEWAY_PYTHON" \
+            "$VENV_DIR/bin/python" \
             "$GATEWAY_SUPERVISOR" \
             "$GATEWAY_LAUNCHER" \
             "$ready_file" \

--- a/tests/test_dashboard_ingress_patches.py
+++ b/tests/test_dashboard_ingress_patches.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import errno
 import os
 import runpy
+import shlex
 import signal
 import subprocess
 import sys
@@ -26,6 +27,92 @@ NGINX_TEMPLATE = ROOT / "hermes_agent" / "nginx.conf.tpl"
 NGINX_PORTS_TEMPLATE = ROOT / "hermes_agent" / "nginx-ports.conf.tpl"
 ADDON_CONFIG = ROOT / "hermes_agent" / "config.yaml"
 LANDING_TEMPLATE = ROOT / "hermes_agent" / "landing.html.tpl"
+
+
+def hermes_gateway_subcommand(command_line: str | None) -> str | None:
+    """Mirror Hermes v2026.8.19's complete gateway command-line recognizer."""
+    if not command_line:
+        return None
+    try:
+        raw_tokens = shlex.split(command_line, posix=False)
+    except ValueError:
+        raw_tokens = command_line.split()
+    tokens = [
+        token.strip("\"'").replace("\\", "/").lower()
+        for token in raw_tokens
+    ]
+    for token in tokens:
+        if token == "gateway/run.py" or token.endswith("/gateway/run.py"):
+            return "run"
+        if token.rsplit("/", 1)[-1] in (
+            "hermes-gateway",
+            "hermes-gateway.exe",
+        ):
+            return "run"
+
+    joined = " ".join(tokens)
+    has_gateway_entry = (
+        "hermes_cli.main" in joined
+        or "hermes_cli/main.py" in joined
+        or any(
+            token.rsplit("/", 1)[-1] in ("hermes", "hermes.exe")
+            for token in tokens
+        )
+    )
+    if not has_gateway_entry:
+        return None
+
+    filtered: list[str] = []
+    skip_next = False
+    for token in tokens:
+        if skip_next:
+            skip_next = False
+            continue
+        if token in ("--profile", "-p"):
+            skip_next = True
+            continue
+        if token.startswith("--profile=") or token.startswith("-p="):
+            continue
+        filtered.append(token)
+
+    for index, token in enumerate(filtered):
+        if token != "gateway":
+            continue
+        if index + 1 >= len(filtered):
+            return "run"
+        return filtered[index + 1]
+    return None
+
+
+def looks_like_hermes_gateway(command_line: str | None) -> bool:
+    return hermes_gateway_subcommand(command_line) == "run"
+
+
+def create_gateway_test_python(root: Path) -> Path:
+    """Create the production sibling interpreter layout inside a test-owned tree."""
+    bin_dir = root / "gateway-venv" / "bin"
+    bin_dir.mkdir(parents=True)
+    python_path = bin_dir / "python"
+    python_path.symlink_to(sys.executable)
+    (bin_dir / "hermes-gateway").symlink_to("python")
+    return python_path
+
+
+def process_command_line(pid: int) -> str:
+    """Read one real process command line without narrowing its argv shape."""
+    proc_cmdline = Path(f"/proc/{pid}/cmdline")
+    if proc_cmdline.exists():
+        return " ".join(
+            os.fsdecode(argument)
+            for argument in proc_cmdline.read_bytes().split(b"\0")
+            if argument
+        )
+    return subprocess.run(
+        ["/bin/ps", "-ww", "-p", str(pid), "-o", "command="],
+        check=True,
+        text=True,
+        capture_output=True,
+    ).stdout.strip()
 
 
 def run_dashboard_patches(src: Path, status_file: Path) -> subprocess.CompletedProcess[str]:
@@ -424,9 +511,128 @@ class DashboardIngressPatchTests(unittest.TestCase):
                 "/usr/local/lib/hermes-gateway-launcher.py",
                 "gateway",
                 "run",
+                "--external-supervisor",
             ],
         )
         self.assertNotIn("executable", keyword)
+
+    def test_gateway_supervisor_argv_is_not_discovered_as_gateway_runtime(self) -> None:
+        run_text = RUN_SH.read_text()
+        child_text = GATEWAY_CHILD.read_text()
+        supervisor_text = GATEWAY_SUPERVISOR.read_text()
+        launch_start = run_text.index('exec "$GATEWAY_CHILD"')
+        launch_end = run_text.index('> "$log_pipe" 2>&1', launch_start)
+        launch_block = run_text[launch_start:launch_end]
+
+        self.assertIn('"$VENV_DIR/bin/python"', launch_block)
+        self.assertNotIn('"$GATEWAY_PYTHON"', launch_block)
+        self.assertIn(
+            'exec "$python_path" "$supervisor" \\\n'
+            '    "$launcher" "$ready_path" "$parent_pid"',
+            child_text,
+        )
+        self.assertIn(
+            'Path(sys.executable).with_name("hermes-gateway")', supervisor_text
+        )
+
+        old_supervisor_argv = " ".join(
+            (
+                "/venv/bin/hermes-gateway",
+                "/usr/local/lib/hermes-gateway-supervisor.py",
+                "--environment-fd",
+                "7",
+                "/venv/bin/hermes-gateway",
+                "/usr/local/lib/hermes-gateway-launcher.py",
+                "/run/hermes-gateway-0.ready",
+                "1",
+            )
+        )
+        supervisor_argv = " ".join(
+            (
+                "/venv/bin/python",
+                "/usr/local/lib/hermes-gateway-supervisor.py",
+                "--environment-fd",
+                "7",
+                "/usr/local/lib/hermes-gateway-launcher.py",
+                "/run/hermes-gateway-0.ready",
+                "1",
+            )
+        )
+        runtime_argv = " ".join(
+            (
+                "/venv/bin/hermes-gateway",
+                "/usr/local/lib/hermes-gateway-launcher.py",
+                "gateway",
+                "run",
+                "--external-supervisor",
+            )
+        )
+        self.assertTrue(looks_like_hermes_gateway(old_supervisor_argv))
+        self.assertFalse(looks_like_hermes_gateway(supervisor_argv))
+        self.assertNotIn("--external-supervisor", shlex.split(supervisor_argv))
+        self.assertTrue(looks_like_hermes_gateway(runtime_argv))
+        self.assertIn("--external-supervisor", shlex.split(runtime_argv))
+
+    def test_gateway_supervisor_clean_reexec_exposes_only_child_as_gateway(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            gateway_python = create_gateway_test_python(root)
+            launcher = root / "launcher.py"
+            runtime_ready = root / "runtime.ready"
+            supervisor_ready = root / "supervisor.ready"
+            launcher.write_text(
+                "import os,signal,sys,time\n"
+                "from pathlib import Path\n"
+                "Path(os.environ['RUNTIME_READY']).write_text(str(os.getpid()))\n"
+                "signal.signal(signal.SIGTERM, lambda *_: sys.exit(0))\n"
+                "while True: time.sleep(0.05)\n"
+            )
+            supervisor = subprocess.Popen(
+                [
+                    str(GATEWAY_CHILD),
+                    str(gateway_python),
+                    str(GATEWAY_SUPERVISOR),
+                    str(launcher),
+                    str(supervisor_ready),
+                    str(os.getpid()),
+                ],
+                env=os.environ | {"RUNTIME_READY": str(runtime_ready)},
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+            try:
+                for _ in range(100):
+                    if runtime_ready.exists() and supervisor_ready.exists():
+                        break
+                    time.sleep(0.02)
+                self.assertTrue(runtime_ready.exists(), "gateway child did not publish readiness")
+                self.assertTrue(
+                    supervisor_ready.exists(), "gateway supervisor did not publish readiness"
+                )
+                runtime_pid = int(runtime_ready.read_text())
+                self.assertEqual(int(supervisor_ready.read_text()), supervisor.pid)
+                command_lines = {
+                    supervisor.pid: process_command_line(supervisor.pid),
+                    runtime_pid: process_command_line(runtime_pid),
+                }
+                self.assertNotIn(
+                    "--external-supervisor", shlex.split(command_lines[supervisor.pid])
+                )
+                self.assertIn(
+                    "--external-supervisor", shlex.split(command_lines[runtime_pid])
+                )
+                discovered = sorted(
+                    pid
+                    for pid, command_line in command_lines.items()
+                    if looks_like_hermes_gateway(command_line)
+                )
+                self.assertEqual(discovered, [runtime_pid], command_lines)
+            finally:
+                try:
+                    os.killpg(supervisor.pid, signal.SIGTERM)
+                except ProcessLookupError:
+                    pass
+                supervisor.wait(timeout=5)
 
     def test_run_creates_recognizable_gateway_link_inside_venv(self) -> None:
         run_text = RUN_SH.read_text()
@@ -481,6 +687,7 @@ class DashboardIngressPatchTests(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
+            gateway_python = create_gateway_test_python(root)
             launcher = root / "launcher.py"
             detached_pid_file = root / "detached.pid"
             supervisor_ready = root / "supervisor.ready"
@@ -498,7 +705,7 @@ class DashboardIngressPatchTests(unittest.TestCase):
             result = subprocess.run(
                 [
                     str(GATEWAY_CHILD),
-                    sys.executable,
+                    str(gateway_python),
                     str(GATEWAY_SUPERVISOR),
                     str(launcher),
                     str(supervisor_ready),
@@ -537,6 +744,7 @@ class DashboardIngressPatchTests(unittest.TestCase):
         secret = "supervisor-must-not-retain-this-handoff"
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
+            gateway_python = create_gateway_test_python(root)
             launcher = root / "launcher.py"
             observed = root / "observed"
             ready = root / "ready"
@@ -556,7 +764,7 @@ class DashboardIngressPatchTests(unittest.TestCase):
             process = subprocess.Popen(
                 [
                     str(GATEWAY_CHILD),
-                    sys.executable,
+                    str(gateway_python),
                     str(GATEWAY_SUPERVISOR),
                     str(launcher),
                     str(supervisor_ready),
@@ -606,6 +814,7 @@ class DashboardIngressPatchTests(unittest.TestCase):
     def test_gateway_supervisor_rejects_changed_parent_before_launch(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
+            gateway_python = create_gateway_test_python(root)
             launcher = root / "launcher.py"
             marker = root / "gateway-started"
             ready = root / "supervisor.ready"
@@ -617,7 +826,7 @@ class DashboardIngressPatchTests(unittest.TestCase):
             result = subprocess.run(
                 [
                     str(GATEWAY_CHILD),
-                    sys.executable,
+                    str(gateway_python),
                     str(GATEWAY_SUPERVISOR),
                     str(launcher),
                     str(ready),
@@ -686,6 +895,7 @@ class DashboardIngressPatchTests(unittest.TestCase):
         helper_end = run_text.index("\nshutdown() {", helper_start)
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
+            gateway_python = create_gateway_test_python(root)
             helper = root / "supervisor.sh"
             helper.write_text(run_text[helper_start:helper_end])
             launcher = root / "gateway.py"
@@ -732,7 +942,7 @@ class DashboardIngressPatchTests(unittest.TestCase):
                     "logger-supervisor-test",
                     str(helper),
                     str(GATEWAY_CHILD),
-                    sys.executable,
+                    str(gateway_python),
                     str(launcher),
                     str(fifo),
                     str(GATEWAY_LOGGER),
@@ -846,7 +1056,7 @@ class DashboardIngressPatchTests(unittest.TestCase):
         unblock = supervisor_text.index("signal.SIG_UNBLOCK", resumed_contract)
         publish_ready = supervisor_text.index("_publish_ready(ready_path)", unblock)
         launch = supervisor_text.index(
-            "return supervise(python_path, launcher, gateway_environment)",
+            "return supervise(gateway_executable, launcher, gateway_environment)",
             publish_ready,
         )
         self.assertLess(initial_block, initial_contract)
@@ -872,6 +1082,7 @@ class DashboardIngressPatchTests(unittest.TestCase):
         self.assertNotIn("tee", child_text)
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
+            gateway_python = create_gateway_test_python(root)
             fake_launcher = root / "launcher.py"
             fake_launcher.write_text(
                 "import os, signal, subprocess, sys, time\n"
@@ -916,7 +1127,7 @@ class DashboardIngressPatchTests(unittest.TestCase):
             def gateway_command(ready_path: Path) -> list[str]:
                 return [
                     str(GATEWAY_CHILD),
-                    sys.executable,
+                    str(gateway_python),
                     str(GATEWAY_SUPERVISOR),
                     str(fake_launcher),
                     str(ready_path),
@@ -957,7 +1168,10 @@ class DashboardIngressPatchTests(unittest.TestCase):
             self.assertIn("term-output", output)
             self.assertIn("gateway exited with status 42", output)
             self.assertIn("owned descendants empty", output)
-            self.assertEqual(args_file.read_text().strip(), "gateway run")
+            self.assertEqual(
+                args_file.read_text().strip(),
+                "gateway run --external-supervisor",
+            )
 
             pid_file.unlink()
             pgid_file.unlink()


### PR DESCRIPTION
## Summary

- launch the per-slot gateway supervisor through the ordinary virtualenv Python executable
- derive the recognizable `hermes-gateway` interpreter only inside the supervisor for the final runtime child
- add a real-process regression proving that Hermes discovery ignores the clean-reexecuted supervisor while still recognizing the runtime child

## Problem

Hermes `v2026.8.19` recognizes a gateway when any command-line token has the basename `hermes-gateway`. The add-on launched the outer per-slot supervisor through that alias and also used it for the actual gateway child, so both processes were discoverable as gateways.

This is operationally significant because update and stop flows consume the discovered PID set and may treat an extra unassigned process as a manual gateway. The final runtime also needs the `--external-supervisor` marker: without it, `hermes update` can launch a detached restart watcher while the add-on's own slot loop starts another replacement.

## Fix

The launcher now starts `gateway-supervisor.py` with `venv/bin/python`, keeping `hermes-gateway` out of the supervisor command line entirely. After its clean re-exec, the supervisor derives the sibling `venv/bin/hermes-gateway` path from `sys.executable` and uses that alias only for the final gateway runtime child. That runtime carries `--external-supervisor`, so Hermes update hands restart ownership back to the add-on slot loop instead of spawning a detached watcher.

The virtualenv import behavior introduced in #38 remains intact while process discovery now has one runtime target per slot.

## Verification

- initial RED reproduced the merged behavior: supervisor discoverable, runtime discoverable
- the real-process regression observes supervisor and child command lines after clean re-exec and requires exactly the child PID to match the Hermes `v2026.8.19` basename contract
- mutation check: restoring the recognizable alias as the clean-reexec supervisor `argv[0]` fails at that matcher oracle
- exact Hermes `v2026.8.19` update selector: runtime marker chooses `external-supervisor`; the unmarked form chooses the detached watcher
- full local suite: 120 tests total, 2 environment-dependent tests skipped
- Bash syntax: 7 shipped scripts passed
- YAML parse and `git diff --check`: passed
- real isolated HAOS/Supervisor smoke: passed - the supervisor was ignored, the runtime was uniquely discovered, the update selector chose the external supervisor, one clean handback replacement completed, the ready marker rebound, and all disposable resources were removed

## Scope

This is a focused lifecycle follow-up to #38. The previously completed hot-backup, restore, durable-data, and first-use LSP reconstruction evidence remains valid; those code paths are unchanged.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wolframravenwolf/hermes-ha-addon/pull/39" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
