### PR TITLE
Release v1.3.2 with legacy gateway compatibility

### DIFF
--- a/hermes_agent/CHANGELOG.md
+++ b/hermes_agent/CHANGELOG.md
@@ -6,6 +6,8 @@ The format follows the spirit of [Keep a Changelog](https://keepachangelog.com/e
 
 ## [Unreleased]
 
+## [1.3.2] - 2026-08-27
+
 ### Changed
 
 - Reduce backup size by excluding only regenerated shared venv, project/dashboard dependencies, profile LSP runtimes, and `.cache`/`.npm` caches. The first start or first LSP use after a restore can be slower and network-dependent; canonical state, user-managed tools, and browser profiles/login state remain backed up.
@@ -15,7 +17,15 @@ The format follows the spirit of [Keep a Changelog](https://keepachangelog.com/e
 - Reduce Linux gateway-supervisor process-tree snapshots from 20 per second to one every two seconds while preserving 50 ms exit and signal responsiveness, immediate cleanup scans, and the existing non-Linux containment behavior.
 - Publish add-on launcher processes with the recognized `hermes-gateway` command identity so Hermes Dashboard liveness correctly reports s6-supervised gateways as running.
 - Preserve Linux virtualenv discovery while publishing that identity by starting a venv-local `hermes-gateway` interpreter symlink directly; this prevents startup from losing installed packages such as `hermes_cli`.
-- Keep the per-slot supervisor out of Hermes gateway process discovery by running it through ordinary venv Python and deriving the recognizable `hermes-gateway` alias only for the final child; status and update flows no longer treat the supervisor as an extra manual gateway, and updates hand the runtime back to the slot supervisor instead of launching a detached restart watcher.
+- Keep the per-slot supervisor out of Hermes Gateway process discovery by running it through ordinary venv Python and deriving the recognizable `hermes-gateway` alias only for the final child; status and update flows no longer treat the supervisor as an extra manual gateway.
+- Keep older pinned Hermes revisions startable when they predate `--external-supervisor`: the add-on launcher feature-detects the installed Gateway parser and removes only the unsupported Python argument, while modern revisions retain the external supervisor handback marker.
+
+### Verified
+
+- `PYTHONDONTWRITEBYTECODE=1 python -B -m unittest discover -s tests -q` with Python 3.11.15 - 122 tests OK, 2 skipped.
+- Shell syntax for every shipped `hermes_agent/*.sh` file, Python AST parsing, YAML parsing, and `git diff --check` passed.
+- A real Home Assistant Supervisor backup/restore smoke proved that only rebuildable runtime data was excluded, canonical state and configuration survived restore, and the excluded runtime was reconstructed successfully.
+- A real HAOS process-lifecycle smoke against live `/proc` command lines proved that only the gateway child matched Hermes discovery, exactly one update target existed, only the child carried `--external-supervisor`, update handback replaced the child through the fixed slot, and no detached restart watcher was launched.
 
 ## [1.3.1] - 2026-07-31
 

--- a/hermes_agent/config.yaml
+++ b/hermes_agent/config.yaml
@@ -1,5 +1,5 @@
 name: Hermes Agent
-version: "1.3.1"
+version: "1.3.2"
 slug: hermes_agent
 description: "The self-improving AI agent built by Nous Research. Home Assistant add-on by Wolfram Ravenwolf."
 url: "https://github.com/WolframRavenwolf/hermes-ha-addon"

--- a/hermes_agent/gateway-launcher.py
+++ b/hermes_agent/gateway-launcher.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import importlib
 import os
 from pathlib import Path
+import sys
+from types import CodeType
 from typing import Any
 
 _HANDOFF = {
@@ -17,6 +19,58 @@ _HANDOFF = {
     "HERMES_ADDON_GATEWAY_NO_SUPERVISE": "HERMES_GATEWAY_NO_SUPERVISE",
     "HERMES_ADDON_SUPERVISED_CHILD": "HERMES_S6_SUPERVISED_CHILD",
 }
+_EXTERNAL_SUPERVISOR_FLAG = "--external-supervisor"
+_GATEWAY_PARSER_MODULE = "hermes_cli.subcommands.gateway"
+
+
+def _code_contains_external_supervisor(code: CodeType) -> bool:
+    """Detect the exact CLI feature in parser bytecode, including nested code."""
+    return any(
+        constant == _EXTERNAL_SUPERVISOR_FLAG
+        or (
+            isinstance(constant, CodeType)
+            and _code_contains_external_supervisor(constant)
+        )
+        for constant in code.co_consts
+    )
+
+
+def _supports_external_supervisor(
+    import_module: Any = importlib.import_module,
+) -> bool:
+    """Feature-detect the installed editable Hermes CLI without version guessing."""
+    try:
+        parser_module = import_module(_GATEWAY_PARSER_MODULE)
+    except ModuleNotFoundError as error:
+        missing = error.name or ""
+        if _GATEWAY_PARSER_MODULE == missing or _GATEWAY_PARSER_MODULE.startswith(
+            f"{missing}."
+        ):
+            return False
+        raise
+
+    return any(
+        isinstance(code, CodeType) and _code_contains_external_supervisor(code)
+        for code in (
+            getattr(value, "__code__", None)
+            for value in vars(parser_module).values()
+        )
+    )
+
+
+def _remove_unsupported_external_supervisor(
+    import_module: Any = importlib.import_module,
+) -> None:
+    """Keep old pinned Hermes revisions startable while preserving modern handback."""
+    if _EXTERNAL_SUPERVISOR_FLAG not in sys.argv:
+        return
+    if _supports_external_supervisor(import_module):
+        return
+    sys.argv[:] = [
+        argument
+        for argument in sys.argv
+        if argument != _EXTERNAL_SUPERVISOR_FLAG
+    ]
 
 
 def _capture_protected_values() -> dict[str, str]:
@@ -118,6 +172,7 @@ def main() -> None:
     _guard_env_loader(env_loader, protected)
 
     hermes_main = _import_fixed_profile_main()
+    _remove_unsupported_external_supervisor()
 
     from gateway import config as gateway_config  # type: ignore[import-not-found]
 

--- a/tests/test_api_server_config.py
+++ b/tests/test_api_server_config.py
@@ -533,6 +533,69 @@ class StartupContractTests(unittest.TestCase):
         self.assertIs(selected, fake_main.main)
         self.assertEqual(imports, ["hermes_cli.main"])
 
+    def test_gateway_launcher_strips_external_supervisor_for_legacy_cli(self):
+        import importlib.util
+
+        spec = importlib.util.spec_from_file_location(
+            "hermes_gateway_launcher_legacy_flag_test",
+            GATEWAY_LAUNCHER,
+        )
+        assert spec is not None and spec.loader is not None
+        launcher = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(launcher)
+
+        def import_module(name):
+            raise ModuleNotFoundError(name="hermes_cli.subcommands")
+
+        argv = [
+            "gateway-launcher.py",
+            "gateway",
+            "run",
+            "--external-supervisor",
+        ]
+        with mock.patch.object(sys, "argv", argv):
+            launcher._remove_unsupported_external_supervisor(import_module)
+            self.assertEqual(
+                sys.argv,
+                ["gateway-launcher.py", "gateway", "run"],
+            )
+
+    def test_gateway_launcher_preserves_external_supervisor_for_modern_cli(self):
+        import importlib.util
+
+        spec = importlib.util.spec_from_file_location(
+            "hermes_gateway_launcher_modern_flag_test",
+            GATEWAY_LAUNCHER,
+        )
+        assert spec is not None and spec.loader is not None
+        launcher = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(launcher)
+        parser_module = types.ModuleType("hermes_cli.subcommands.gateway")
+
+        def build_gateway_parser():
+            return "--external-supervisor"
+
+        setattr(parser_module, "build_gateway_parser", build_gateway_parser)
+        argv = [
+            "gateway-launcher.py",
+            "gateway",
+            "run",
+            "--external-supervisor",
+        ]
+        with mock.patch.object(sys, "argv", argv):
+            launcher._remove_unsupported_external_supervisor(
+                lambda name: parser_module
+            )
+            self.assertEqual(
+                sys.argv,
+                [
+                    "gateway-launcher.py",
+                    "gateway",
+                    "run",
+                    "--external-supervisor",
+                ],
+            )
+
     def test_gateway_config_guard_enforces_enabled_and_disabled_values(self):
         self.assertTrue(GATEWAY_LAUNCHER.is_file())
         import importlib.util
@@ -738,11 +801,11 @@ class ReservedApiVariableTests(unittest.TestCase):
 
 
 class PublicationMetadataTests(unittest.TestCase):
-    def test_addon_version_is_1_3_1(self):
+    def test_addon_version_is_1_3_2(self):
         config = CONFIG.read_text()
         match = re.search(r'^version:\s*["\']?([^"\'\s]+)', config, re.MULTILINE)
         self.assertIsNotNone(match)
-        self.assertEqual(match.group(1) if match else None, "1.3.1")
+        self.assertEqual(match.group(1) if match else None, "1.3.2")
 
     def test_translation_describes_api_password_policy(self):
         translation = TRANSLATION.read_text().lower()
@@ -815,14 +878,22 @@ class PublicationMetadataTests(unittest.TestCase):
 
     def test_release_changelog_records_actual_verification(self):
         changelog = CHANGELOG.read_text()
-        release = changelog.split("## [1.3.1] - 2026-07-31", 1)[1].split(
+        unreleased = changelog.split("## [Unreleased]", 1)[1].split(
             "\n## [", 1
         )[0]
+        release = changelog.split("## [1.3.2] - 2026-08-27", 1)[1].split(
+            "\n## [", 1
+        )[0]
+        self.assertEqual(unreleased.strip(), "")
+        self.assertIn("### Changed", release)
         self.assertIn("### Fixed", release)
-        self.assertIn("### Security", release)
         self.assertIn("### Verified", release)
-        self.assertIn("108 tests OK, 2 skipped", release)
-        self.assertIn("30 credential cases", release)
+        self.assertIn("backup size", release)
+        self.assertIn("`hermes-gateway`", release)
+        self.assertIn("external supervisor", release)
+        self.assertIn("122 tests OK, 2 skipped", release)
+        self.assertIn("older pinned Hermes revisions", release)
+        self.assertIn("Home Assistant", release)
         self.assertNotIn("Pending final publication verification", release)
 
 

--- a/tests/test_backup_policy.py
+++ b/tests/test_backup_policy.py
@@ -226,9 +226,9 @@ class BackupDocumentationTests(unittest.TestCase):
             backup_section,
         )
 
-    def test_changelog_records_backup_reconstruction_and_retention(self):
-        unreleased = CHANGELOG.read_text().split("## [Unreleased]", 1)[1]
-        unreleased = unreleased.split("\n## [", 1)[0].lower()
+    def test_v1_3_2_changelog_records_backup_reconstruction_and_retention(self):
+        release = CHANGELOG.read_text().split("## [1.3.2] - 2026-08-27", 1)[1]
+        release = release.split("\n## [", 1)[0].lower()
         for phrase in (
             "regenerated",
             "slower",
@@ -239,7 +239,7 @@ class BackupDocumentationTests(unittest.TestCase):
             "remain backed up",
         ):
             with self.subTest(phrase=phrase):
-                self.assertIn(phrase, unreleased)
+                self.assertIn(phrase, release)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Release Hermes Agent Home Assistant add-on v1.3.2 with the merged backup, runtime-health, and gateway lifecycle fixes.
- Keep older pinned Hermes revisions startable when they predate the `--external-supervisor` gateway option.
- Detect support from the installed Gateway parser instead of relying on an unreliable editable-install package version.
- Preserve the external-supervisor handback marker unchanged for modern Hermes revisions.

## Why

The gateway identity fix correctly passes `--external-supervisor` to current Hermes releases, but the add-on supports pinned Git revisions and older revisions such as `v2026.5.28` do not define that CLI option. Without compatibility handling, those installations would fail during argument parsing after updating the add-on.

The launcher now removes the unsupported option from Python's argument list only when the installed parser does not define it. The original process command line remains recognizable to lifecycle discovery, while current Hermes releases continue receiving the option normally.

## Verification

- Focused release and compatibility contracts: 5 passed.
- Full suite: 122 passed, 2 expected skips.
- Immutable Hermes tag differential:
  - `v2026.5.28`: unsupported
  - `v2026.7.7`: unsupported with modular parser present
  - `v2026.8.19`: supported
- Shell syntax, Python AST, YAML parsing, `git diff --check`, exact five-file scope, and secret-shaped addition gates passed.
- Existing real Home Assistant Supervisor backup/restore and HAOS gateway lifecycle smokes remain documented in the v1.3.2 changelog.

The tag and GitHub Release will be created only after the merged candidate is delivered through the Home Assistant Store and the existing stopped non-production installation passes its bounded update/start/readiness/identity/stop smoke.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wolframravenwolf/hermes-ha-addon/pull/40" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->